### PR TITLE
Fix WithErrorHandling being ignored on the ExecuteAsync injection path

### DIFF
--- a/Runtime/ServiceInjectionBuilder.cs
+++ b/Runtime/ServiceInjectionBuilder.cs
@@ -70,9 +70,10 @@ namespace Nonatomic.ServiceKit
 			{
 				await ExecuteAsync();
 			}
-			catch (Exception ex)
+			catch (Exception)
 			{
-				_errorHandler?.Invoke(ex);
+				// The error handler (if any) is already invoked inside ExecuteAsync.
+				// Swallow here so the fire-and-forget call doesn't raise an unobserved exception.
 			}
 		}
 
@@ -96,9 +97,10 @@ namespace Nonatomic.ServiceKit
 				await ExecuteWithCancellationAsync(destroyCancellationToken);
 #endif
 			}
-			catch (Exception ex)
+			catch (Exception)
 			{
-				_errorHandler?.Invoke(ex);
+				// The error handler (if any) is already invoked inside ExecuteAsync.
+				// Swallow here so the fire-and-forget call doesn't raise an unobserved exception.
 			}
 		}
 
@@ -164,7 +166,18 @@ namespace Nonatomic.ServiceKit
 					return;
 				}
 
-				throw BuildTimeoutException(fieldsToInject, isExplicitTimeout);
+				// Route the failure through the configured handler (if any) before surfacing it.
+				var timeoutException = BuildTimeoutException(fieldsToInject, isExplicitTimeout);
+				_errorHandler?.Invoke(timeoutException);
+				throw timeoutException;
+			}
+			catch (Exception ex)
+			{
+				// Covers required-services-missing and circular-dependency failures.
+				// The handler is invoked here so WithErrorHandling works on the awaited
+				// ExecuteAsync path, not only the fire-and-forget Execute() path.
+				_errorHandler?.Invoke(ex);
+				throw;
 			}
 			finally
 			{

--- a/Runtime/ServiceKitBehaviour.cs
+++ b/Runtime/ServiceKitBehaviour.cs
@@ -115,7 +115,19 @@ namespace Nonatomic.ServiceKit
 		private async Task PerformServiceInitializationSequence()
 #endif
 		{
-			await InjectDependenciesAsync();
+			try
+			{
+				await InjectDependenciesAsync();
+			}
+			catch (Exception)
+			{
+				// Dependency injection failed. HandleDependencyInjectionFailure has already
+				// been invoked via the injection builder's error handler. Stop here so the
+				// failure does not surface as an unhandled async-void exception and the
+				// service is not marked ready with unsatisfied dependencies.
+				return;
+			}
+
 			await InitializeServiceAsync();
 
 			InitializeService();

--- a/Tests/EditMode/ErrorHandlingBehaviorTest.cs
+++ b/Tests/EditMode/ErrorHandlingBehaviorTest.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Nonatomic.ServiceKit;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
 namespace Tests.EditMode
@@ -46,6 +48,49 @@ namespace Tests.EditMode
 		}
 		
 		[Test]
+		public async Task ExecuteAsync_WithErrorHandler_InvokesHandlerAndStillThrows()
+		{
+			// Contract: when a handler is supplied via WithErrorHandling, ExecuteAsync must
+			// route the failure through that handler (and still surface the exception to the
+			// awaiter). Previously the handler was silently ignored on the ExecuteAsync path.
+
+			// Arrange
+			var consumer = new ConsumerWithRequiredDependency();
+			bool errorHandlerCalled = false;
+			Exception handlerException = null;
+
+			// Don't register the required service to force a failure.
+
+			// Act
+			Exception caughtException = null;
+			try
+			{
+				using (var cts = new CancellationTokenSource(100))
+				{
+					await _serviceLocator.Inject(consumer)
+						.WithCancellation(cts.Token)
+						.WithErrorHandling(ex =>
+						{
+							errorHandlerCalled = true;
+							handlerException = ex;
+						})
+						.ExecuteAsync();
+				}
+
+				Assert.Fail("ExecuteAsync should have thrown an exception");
+			}
+			catch (Exception ex)
+			{
+				caughtException = ex;
+			}
+
+			// Assert
+			Assert.IsTrue(errorHandlerCalled, "Error handler MUST be invoked on the ExecuteAsync path");
+			Assert.IsNotNull(handlerException, "Handler should receive the failure exception");
+			Assert.IsNotNull(caughtException, "ExecuteAsync should still surface the exception to the awaiter");
+		}
+
+		[Test]
 		public async Task ExecuteAsync_WithErrorHandler_ShouldStillThrow()
 		{
 			// This test verifies that ExecuteAsync throws even when WithErrorHandling is used
@@ -87,9 +132,10 @@ namespace Tests.EditMode
 			Assert.IsTrue(caughtException is ServiceInjectionException || caughtException is TimeoutException || caughtException is OperationCanceledException,
 				$"Expected ServiceInjectionException, TimeoutException, or OperationCanceledException, got {caughtException.GetType().Name}");
 			
-			// The error handler should NOT have been called because ExecuteAsync doesn't use it
-			Assert.IsFalse(errorHandlerCalled, 
-				"Error handler should NOT be called when using ExecuteAsync");
+			// The error handler IS invoked on the ExecuteAsync path, and the exception still surfaces.
+			Assert.IsTrue(errorHandlerCalled,
+				"Error handler should be invoked when using ExecuteAsync");
+			Assert.IsNotNull(handlerException, "Handler should receive the failure exception");
 		}
 		
 		[Test]
@@ -165,8 +211,8 @@ namespace Tests.EditMode
 				"Should throw TimeoutException for registered but not ready optional dependency");
 			Assert.IsTrue(caughtException is TimeoutException,
 				$"Expected TimeoutException, got {caughtException?.GetType().Name}");
-			Assert.IsFalse(errorHandlerCalled,
-				"Error handler should NOT be called with ExecuteAsync");
+			Assert.IsTrue(errorHandlerCalled,
+				"Error handler should be invoked with ExecuteAsync");
 			Assert.IsNull(consumer.OptionalService,
 				"Service should not be injected after timeout");
 		}
@@ -182,10 +228,13 @@ namespace Tests.EditMode
 			bool errorHandlerCalled = false;
 			bool initializeServiceCalled = false;
 			bool dependencyWasNull = false;
-			
+
+			// The handler now genuinely runs and logs an error; expect it so the test passes.
+			LogAssert.Expect(LogType.Error, new Regex("Failed to inject required services"));
+
 			// Register but don't ready the service (simulates registered but not initialized)
 			_serviceLocator.RegisterService<ITestService>(service);
-			
+
 			// Act - Simulate ServiceKitBehaviour's PerformServiceInitializationSequence
 			async Task SimulateServiceKitFlow()
 			{
@@ -240,17 +289,14 @@ namespace Tests.EditMode
 			}
 			
 			// Assert
-			Assert.IsTrue(flowThrewException, 
+			Assert.IsTrue(flowThrewException,
 				"Flow should throw TimeoutException");
-			Assert.IsFalse(errorHandlerCalled,
-				"Error handler should NOT be called with ExecuteAsync (this is a bug in the API design)");
+			Assert.IsTrue(errorHandlerCalled,
+				"Error handler IS invoked on the ExecuteAsync path");
 			Assert.IsFalse(initializeServiceCalled,
 				"InitializeService should NOT be called after injection failure");
 			Assert.IsNull(consumer.OptionalService,
 				"Optional service should remain null after timeout");
-			
-			// The issue is that WithErrorHandling doesn't work with ExecuteAsync!
-			// ServiceKitBehaviour thinks it's handling errors, but it's not.
 		}
 	}
 }

--- a/Tests/EditMode/InitializeServiceRaceConditionTest.cs
+++ b/Tests/EditMode/InitializeServiceRaceConditionTest.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Nonatomic.ServiceKit;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
 #if SERVICEKIT_UNITASK
@@ -144,12 +146,15 @@ namespace Tests.EditMode
 			// ServiceA is registered but never becomes ready
 			
 			// Arrange
+			// The injection failure now genuinely routes through the error handler, which logs.
+			LogAssert.Expect(LogType.Error, new Regex("Failed to inject required services"));
+
 			var serviceA = new ServiceA();
 			_serviceLocator.RegisterService<IServiceA>(serviceA);
 			// NOT calling ReadyService!
-			
+
 			var serviceB = new ServiceBWithOptionalDependency();
-			
+
 			// Act
 			bool exceptionThrown = false;
 			try
@@ -181,6 +186,10 @@ namespace Tests.EditMode
 			// This simulates the race condition where ServiceA becomes ready
 			// while ServiceB is attempting injection
 			
+			// Timed-out iterations now log via the error handler; the count is non-deterministic,
+			// so ignore error logs here. The AreEqual assertion below is the real guard.
+			LogAssert.ignoreFailingMessages = true;
+
 			const int iterations = 20;
 			int successCount = 0;
 			int failureCount = 0;
@@ -255,12 +264,15 @@ namespace Tests.EditMode
 			// before calling InitializeService
 			
 			// Arrange
+			// The injection failure now genuinely routes through the error handler, which logs.
+			LogAssert.Expect(LogType.Error, new Regex("Failed to inject required services"));
+
 			var serviceA = new ServiceA();
 			_serviceLocator.RegisterService<IServiceA>(serviceA);
 			// Don't ready it to cause timeout
-			
+
 			var serviceB = new ServiceBWithOptionalDependency();
-			
+
 			// Act - Modified flow that checks injection success
 			bool shouldCallInitialize = true;
 			try

--- a/Tests/EditMode/OptionalDependencyRaceConditionTest.cs
+++ b/Tests/EditMode/OptionalDependencyRaceConditionTest.cs
@@ -376,10 +376,9 @@ namespace Tests.EditMode
 			consumer.InitializeService();
 			
 			// Assert
-			// The error handler is NOT called when using ExecuteAsync (only with Execute())
-			// So an exception should be thrown
-			Assert.IsNotNull(caughtException, "Exception should be thrown (WithErrorHandling doesn't work with ExecuteAsync)");
-			Assert.IsFalse(errorHandlerCalled, "Error handler should NOT be called with ExecuteAsync");
+			// The error handler IS invoked on the ExecuteAsync path, and the exception still surfaces.
+			Assert.IsNotNull(caughtException, "Exception should still be surfaced to the awaiter");
+			Assert.IsTrue(errorHandlerCalled, "Error handler should be invoked with ExecuteAsync");
 			Assert.IsFalse(executionContinuedAfterError, "Execution should not continue after exception");
 		}
 	}


### PR DESCRIPTION
## Problem
`WithErrorHandling(...)` was a no-op on the awaited `ExecuteAsync()` path. Since `ServiceKitBehaviour` and the `InjectAsync` extension both await `ExecuteAsync()` directly, the configured handler (incl. `HandleDependencyInjectionFailure`) never fired, and a failed required injection surfaced as an unhandled exception in `async void Awake` while the service could still be marked ready.

## Fix
- `ServiceInjectionBuilder.ExecuteAsync` now routes failures (timeout, required-missing, circular) through `_errorHandler` before surfacing them. The exception still propagates to the awaiter.
- The fire-and-forget `Execute()`/`ExecuteWithCancellation()` wrappers no longer re-invoke the handler (avoids double invocation).
- `ServiceKitBehaviour` catches injection failure: no unhandled async-void exception, and the service is not marked ready with unsatisfied dependencies.

## Tests
- New: `ExecuteAsync_WithErrorHandler_InvokesHandlerAndStillThrows` (failed first on the unfixed code, confirming the bug).
- Updated tests that previously asserted the dead-handler behaviour (these explicitly documented it as a known bug). Failure-path tests that now correctly emit a log use `LogAssert`.
- Full EditMode suite green: 104/104.