### PR TITLE
Harden ServiceKitTimeoutManager: unscaled time and non-latching focus handling

### DIFF
--- a/Runtime/ServiceKitTimeoutManager.cs
+++ b/Runtime/ServiceKitTimeoutManager.cs
@@ -70,7 +70,8 @@ namespace Nonatomic.ServiceKit
 		
 		private void AddTimeoutToActiveList(CancellationTokenSource cancellationSource, float durationInSeconds)
 		{
-			var timeoutEndTime = Time.time + durationInSeconds;
+			// Use unscaled time so injection timeouts still fire when Time.timeScale is 0 (paused game).
+			var timeoutEndTime = Time.unscaledTime + durationInSeconds;
 			lock (_timeoutsSyncLock)
 			{
 				_activeTimeouts.Add((cancellationSource, timeoutEndTime));
@@ -144,7 +145,7 @@ namespace Nonatomic.ServiceKit
 		private void IdentifyExpiredTimeouts()
 		{
 			_pendingRemovalIndices.Clear();
-			var currentTime = Time.time;
+			var currentTime = Time.unscaledTime;
 			
 			for (var i = _activeTimeouts.Count - 1; i >= 0; i--)
 			{
@@ -353,30 +354,45 @@ namespace Nonatomic.ServiceKit
 		
 		private void OnApplicationPause(bool pauseStatus)
 		{
-			if (ShouldHandleEditorShutdown(pauseStatus))
+			if (!IsEditorEditMode()) return;
+
+			if (pauseStatus)
 			{
 				MarkAsShuttingDown();
 				CancelAllPendingTimeouts();
 			}
+			else
+			{
+				// Editor resumed: re-enable the manager so it is not permanently disabled.
+				ClearShuttingDownState();
+			}
 		}
-		
+
 		private void OnApplicationFocus(bool hasFocus)
 		{
-			if (ShouldHandleEditorLostFocus(hasFocus))
+			if (!IsEditorEditMode()) return;
+
+			if (!hasFocus)
 			{
 				MarkAsShuttingDown();
 				CancelAllPendingTimeouts();
 			}
+			else
+			{
+				// Editor regained focus: re-enable the manager so it is not permanently disabled.
+				ClearShuttingDownState();
+			}
 		}
-		
-		private bool ShouldHandleEditorShutdown(bool pauseStatus)
+
+		private static bool IsEditorEditMode()
 		{
-			return pauseStatus && Application.isEditor && !Application.isPlaying;
+			return Application.isEditor && !Application.isPlaying;
 		}
-		
-		private bool ShouldHandleEditorLostFocus(bool hasFocus)
+
+		private static void ClearShuttingDownState()
 		{
-			return !hasFocus && Application.isEditor && !Application.isPlaying;
+			_isCleaningUp = false;
+			_applicationQuitting = false;
 		}
 
 		private void CancelAllPendingTimeouts()

--- a/Tests/EditMode/TimeoutManagerFocusTests.cs
+++ b/Tests/EditMode/TimeoutManagerFocusTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Nonatomic.ServiceKit;
+using NUnit.Framework;
+
+namespace Tests.EditMode
+{
+	/// <summary>
+	/// Verifies that losing and regaining editor focus does not permanently disable the
+	/// timeout manager (previously the focus/pause handlers latched the shutdown flags).
+	/// </summary>
+	[TestFixture]
+	public class TimeoutManagerFocusTests
+	{
+		[SetUp]
+		public void Setup()
+		{
+			// Reset any latched static state from earlier tests.
+			ServiceKitTimeoutManager.Cleanup();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			ServiceKitTimeoutManager.Cleanup();
+		}
+
+		[Test]
+		public void EditorFocusLossThenRegain_DoesNotPermanentlyDisableManager()
+		{
+			var manager = ServiceKitTimeoutManager.Instance;
+			Assert.IsNotNull(manager, "Manager should be created");
+
+			var onFocus = typeof(ServiceKitTimeoutManager)
+				.GetMethod("OnApplicationFocus", BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.IsNotNull(onFocus, "OnApplicationFocus should exist");
+
+			// Simulate the editor losing focus (edit mode), then regaining it.
+			onFocus.Invoke(manager, new object[] { false });
+			onFocus.Invoke(manager, new object[] { true });
+
+			Assert.IsNotNull(ServiceKitTimeoutManager.Instance,
+				"After regaining editor focus the timeout manager must be usable again");
+		}
+	}
+}

--- a/Tests/EditMode/TimeoutManagerFocusTests.cs.meta
+++ b/Tests/EditMode/TimeoutManagerFocusTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6a6281c04bf6d2145b438841892cacac

--- a/Tests/PlayMode/TimeoutManagerUnscaledTimeTests.cs
+++ b/Tests/PlayMode/TimeoutManagerUnscaledTimeTests.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Threading;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Nonatomic.ServiceKit.Tests.PlayMode
+{
+	/// <summary>
+	/// Verifies the timeout manager uses unscaled time so timeouts still fire while the
+	/// game is paused (Time.timeScale == 0).
+	/// </summary>
+	public class TimeoutManagerUnscaledTimeTests
+	{
+		private float _originalTimeScale;
+
+		[SetUp]
+		public void Setup()
+		{
+			_originalTimeScale = Time.timeScale;
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			Time.timeScale = _originalTimeScale;
+			ServiceKitTimeoutManager.Cleanup();
+		}
+
+		[UnityTest]
+		public IEnumerator Timeout_FiresEvenWhenTimeScaleIsZero()
+		{
+			var manager = ServiceKitTimeoutManager.Instance;
+			Assert.IsNotNull(manager, "Manager should be created");
+
+			var cts = new CancellationTokenSource();
+
+			// Pause the game: scaled time stops advancing entirely.
+			Time.timeScale = 0f;
+
+			manager.RegisterTimeout(cts, 0.1f);
+
+			// Wait in real time (WaitForSeconds would never elapse at timeScale 0).
+			yield return new WaitForSecondsRealtime(0.5f);
+
+			Assert.IsTrue(cts.IsCancellationRequested,
+				"Timeout should fire based on unscaled time even when Time.timeScale is 0");
+
+			cts.Dispose();
+		}
+	}
+}

--- a/Tests/PlayMode/TimeoutManagerUnscaledTimeTests.cs.meta
+++ b/Tests/PlayMode/TimeoutManagerUnscaledTimeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbee2b0bae9cbfc49b8f4827c45ebc0d


### PR DESCRIPTION
## Problems
1. **Scaled time** — timeouts were measured with `Time.time`, which stops advancing when `Time.timeScale == 0`. A service injection timeout would therefore never fire while the game is paused.
2. **Focus latch** — `OnApplicationFocus(false)`/`OnApplicationPause(true)` in edit mode set the static shutdown flags with no reset path. Alt-tabbing away from the editor permanently disabled the timeout manager (`Instance` returned null) for the rest of the session.

## Fix
- Timeouts now use `Time.unscaledTime`.
- The edit-mode focus/pause handlers still cancel pending timeouts on focus/pause loss, but regaining focus / resuming clears the shutdown flags so the manager is usable again.

## Tests
- PlayMode `Timeout_FiresEvenWhenTimeScaleIsZero` — sets `timeScale = 0` and asserts the timeout still fires (failed first on the unfixed code).
- EditMode `EditorFocusLossThenRegain_DoesNotPermanentlyDisableManager` — simulates focus loss then regain via the handlers and asserts `Instance` is still available (failed first on the unfixed code).
- Full suites green: EditMode 104/104, PlayMode 8/8.