### PR TITLE
Complete awaiters outside the lock; register multi-type services before readying

### DIFF
--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Allow the EditMode test assembly to construct internal types (e.g. ServiceRegistrationBuilder)
+// for white-box unit tests.
+[assembly: InternalsVisibleTo("com.nonatomic.servicekit.tests.editmode")]

--- a/Runtime/AssemblyInfo.cs.meta
+++ b/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b1977840ab19234a88dc06222823d3a

--- a/Runtime/ServiceKitLocator.cs
+++ b/Runtime/ServiceKitLocator.cs
@@ -464,7 +464,9 @@ namespace Nonatomic.ServiceKit
 		public async Task<object> GetServiceAsync(Type serviceType, CancellationToken cancellationToken = default)
 		{
 			TaskCompletionSource<object> sharedTcs;
-			var callerTcs = new TaskCompletionSource<object>();
+			// RunContinuationsAsynchronously so awaiter continuations never execute synchronously
+			// on the thread that completes/cancels the TCS (e.g. while the locator holds _lock).
+			var callerTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			lock (_lock)
 			{
@@ -475,7 +477,7 @@ namespace Nonatomic.ServiceKit
 
 				if (!_serviceAwaiters.TryGetValue(serviceType, out sharedTcs))
 				{
-					sharedTcs = new TaskCompletionSource<object>();
+					sharedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 					_serviceAwaiters[serviceType] = sharedTcs;
 				}
 
@@ -534,6 +536,12 @@ namespace Nonatomic.ServiceKit
 
 		public void UnregisterService(Type serviceType)
 		{
+#if SERVICEKIT_UNITASK
+			UniTaskCompletionSource<object> awaiterToCancel = null;
+#else
+			TaskCompletionSource<object> awaiterToCancel = null;
+#endif
+
 			lock (_lock)
 			{
 				var removed = _readyServices.Remove(serviceType) || _registeredServices.Remove(serviceType);
@@ -550,9 +558,12 @@ namespace Nonatomic.ServiceKit
 				if (_serviceAwaiters.TryGetValue(serviceType, out var tcs))
 				{
 					_serviceAwaiters.Remove(serviceType);
-					tcs.TrySetCanceled();
+					awaiterToCancel = tcs;
 				}
 			}
+
+			// Cancel outside the lock so awaiter continuations never run while _lock is held.
+			awaiterToCancel?.TrySetCanceled();
 		}
 
 		public string GetServiceStatus<T>() where T : class
@@ -686,6 +697,12 @@ namespace Nonatomic.ServiceKit
 
 		public void UnregisterServicesFromScene(Scene scene)
 		{
+#if SERVICEKIT_UNITASK
+			var awaitersToCancel = new List<UniTaskCompletionSource<object>>();
+#else
+			var awaitersToCancel = new List<TaskCompletionSource<object>>();
+#endif
+
 			lock (_lock)
 			{
 				var servicesToRemove = new List<Type>();
@@ -741,15 +758,20 @@ namespace Nonatomic.ServiceKit
 					_readyServices.Remove(type);
 					_registeredServices.Remove(type);
 
-
 					if (_serviceAwaiters.TryGetValue(type, out var tcs))
 					{
-						tcs.TrySetCanceled();
 						_serviceAwaiters.Remove(type);
+						awaitersToCancel.Add(tcs);
 					}
 				}
 
 				_trackedScenes.Remove(scene);
+			}
+
+			// Cancel outside the lock so awaiter continuations never run while _lock is held.
+			foreach (var tcs in awaitersToCancel)
+			{
+				tcs.TrySetCanceled();
 			}
 		}
 
@@ -786,28 +808,40 @@ namespace Nonatomic.ServiceKit
 
 		public void ClearServices()
 		{
+#if SERVICEKIT_UNITASK
+			var awaitersToCancel = new List<UniTaskCompletionSource<object>>();
+#else
+			var awaitersToCancel = new List<TaskCompletionSource<object>>();
+#endif
+
 			lock (_lock)
 			{
-				// Cancel all pending service awaiters first
+				// Collect pending awaiters; they are cancelled after releasing the lock.
 				foreach (var kvp in _serviceAwaiters)
 				{
-					try
-					{
-						kvp.Value.TrySetCanceled();
-					}
-					catch
-					{
-						// Ignore any exceptions during cleanup
-					}
+					awaitersToCancel.Add(kvp.Value);
 				}
 				_serviceAwaiters.Clear();
-				
+
 				_readyServices.Clear();
 				_registeredServices.Clear();
 				_trackedScenes.Clear();
 
 				// Clear dependency graph and exemptions
 				_dependencyGraph.ClearAll();
+			}
+
+			// Cancel outside the lock so awaiter continuations never run while _lock is held.
+			foreach (var tcs in awaitersToCancel)
+			{
+				try
+				{
+					tcs.TrySetCanceled();
+				}
+				catch
+				{
+					// Ignore any exceptions during cleanup
+				}
 			}
 		}
 

--- a/Runtime/ServiceRegistrationBuilder.cs
+++ b/Runtime/ServiceRegistrationBuilder.cs
@@ -138,14 +138,22 @@ namespace Nonatomic.ServiceKit
 
 			var tagsArray = _tags.Count > 0 ? _tags.ToArray() : null;
 
+			// Register every type first, then ready them. Otherwise the first type would be
+			// marked ready (firing its awaiters) before the remaining types are even registered,
+			// so a consumer woken by one type could observe the others as not-yet-registered.
 			foreach (var serviceType in _serviceTypes)
 			{
 				RegisterServiceType(serviceType, tagsArray);
+			}
 
-				if (markAsReady)
-				{
-					_locator.ReadyService(serviceType);
-				}
+			if (!markAsReady)
+			{
+				return;
+			}
+
+			foreach (var serviceType in _serviceTypes)
+			{
+				_locator.ReadyService(serviceType);
 			}
 		}
 

--- a/Tests/EditMode/AwaiterCancellationTests.cs
+++ b/Tests/EditMode/AwaiterCancellationTests.cs
@@ -1,0 +1,82 @@
+using System.Threading.Tasks;
+using Nonatomic.ServiceKit;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Tests.EditMode
+{
+	/// <summary>
+	/// Verifies awaiter cancellation does not run continuations synchronously while the locator
+	/// holds its internal lock, and that pending awaiters are still cancelled on teardown.
+	/// </summary>
+	[TestFixture]
+	public class AwaiterCancellationTests
+	{
+		public interface IFoo { }
+		public class Foo : IFoo { }
+
+		private ServiceKitLocator _locator;
+
+		[SetUp]
+		public void Setup()
+		{
+			_locator = ScriptableObject.CreateInstance<ServiceKitLocator>();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (_locator == null) return;
+			_locator.ClearServices();
+			Object.DestroyImmediate(_locator);
+			_locator = null;
+		}
+
+		[Test]
+		public void UnregisterService_DoesNotRunAwaiterContinuationsSynchronously()
+		{
+			// Registered but never readied so the GetServiceAsync call parks an awaiter.
+			_locator.RegisterService<IFoo>(new Foo());
+
+			var task = _locator.GetServiceAsync(typeof(IFoo));
+
+			var ranWhileUnregistering = false;
+			var unregistering = false;
+			_ = task.ContinueWith(_ =>
+			{
+				if (unregistering) ranWhileUnregistering = true;
+			}, TaskContinuationOptions.ExecuteSynchronously);
+
+			unregistering = true;
+			_locator.UnregisterService(typeof(IFoo));
+			unregistering = false;
+
+			Assert.IsFalse(ranWhileUnregistering,
+				"Awaiter continuation must not run synchronously inside UnregisterService (under _lock)");
+		}
+
+		[Test]
+		public async Task ClearServices_CancelsPendingAwaiters()
+		{
+			_locator.RegisterService<IFoo>(new Foo());
+
+			var task = _locator.GetServiceAsync(typeof(IFoo));
+			Assert.IsFalse(task.IsCompleted, "Awaiter should still be pending");
+
+			_locator.ClearServices();
+
+			var cancelled = false;
+			try
+			{
+				await task;
+			}
+			catch (System.OperationCanceledException)
+			{
+				cancelled = true;
+			}
+
+			Assert.IsTrue(cancelled, "Pending awaiter should be cancelled when services are cleared");
+		}
+	}
+}

--- a/Tests/EditMode/AwaiterCancellationTests.cs.meta
+++ b/Tests/EditMode/AwaiterCancellationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5bd08f94cfd5e4e4d95e3abaedfeb394

--- a/Tests/EditMode/MultiTypeRegistrationOrderTests.cs
+++ b/Tests/EditMode/MultiTypeRegistrationOrderTests.cs
@@ -1,0 +1,39 @@
+using Nonatomic.ServiceKit;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Tests.EditMode
+{
+	/// <summary>
+	/// Verifies that a multi-type fluent registration registers every type before readying any
+	/// of them, so a consumer woken by one type never observes the others as not-yet-registered.
+	/// </summary>
+	[TestFixture]
+	public class MultiTypeRegistrationOrderTests
+	{
+		public interface IFoo { }
+		public interface IBar { }
+
+		public class MultiService : IFoo, IBar { }
+
+		[Test]
+		public void FluentReady_RegistersAllTypesBeforeReadyingAny()
+		{
+			var locator = Substitute.For<IServiceKitLocator>();
+			var service = new MultiService();
+
+			new ServiceRegistrationBuilder(locator, service)
+				.As<IFoo>()
+				.As<IBar>()
+				.Ready();
+
+			Received.InOrder(() =>
+			{
+				locator.RegisterService(typeof(IFoo), service, Arg.Any<string>());
+				locator.RegisterService(typeof(IBar), service, Arg.Any<string>());
+				locator.ReadyService(typeof(IFoo));
+				locator.ReadyService(typeof(IBar));
+			});
+		}
+	}
+}

--- a/Tests/EditMode/MultiTypeRegistrationOrderTests.cs.meta
+++ b/Tests/EditMode/MultiTypeRegistrationOrderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 81f47c1f7d5f93845b3d2c2db1cf1f99


### PR DESCRIPTION
## Problems
1. **Continuations under the lock** — `UnregisterService`, `UnregisterServicesFromScene` and `ClearServices` called `TrySetCanceled()` on awaiter TCSs while holding `_lock`, so awaiter continuations could run synchronously under the lock (inconsistent with `CompleteAwaiters`, which deliberately completes outside the lock). The awaiter TCSs were also created without `RunContinuationsAsynchronously`.
2. **Multi-type `Ready()` ordering** — the fluent builder registered and readied each type in the same loop iteration, so the first type fired its awaiters before the remaining types were even registered.

## Fix
- Awaiter `TaskCompletionSource`s are created with `RunContinuationsAsynchronously`, and the three cancellation sites collect awaiters under the lock and cancel them after releasing it.
- `ServiceRegistrationBuilder` registers all types first, then readies them.
- Adds `InternalsVisibleTo` for the EditMode test assembly (white-box ordering test).

## Tests (both failed first on the unfixed code)
- `MultiTypeRegistrationOrderTests.FluentReady_RegistersAllTypesBeforeReadyingAny` — verifies register-all-then-ready ordering via `Received.InOrder`.
- `AwaiterCancellationTests.UnregisterService_DoesNotRunAwaiterContinuationsSynchronously` — proves continuations no longer run synchronously inside `UnregisterService`; plus `ClearServices_CancelsPendingAwaiters` regression.

Full suites green: EditMode 106/106, PlayMode 7/7.

Note: the minor awaiter-retention item (#8) is left as-is — a pending awaiter for a registered-but-never-readied service is expected, and it is reclaimed on ready/unregister/clear/scene-unload.