### PR TITLE
Track scene metadata at runtime so scene cleanup works in player builds

### DIFF
--- a/Runtime/ServiceInfo.cs
+++ b/Runtime/ServiceInfo.cs
@@ -21,6 +21,19 @@ namespace Nonatomic.ServiceKit
 		/// </summary>
 		public List<ServiceTag> Tags { get; set; } = new ();
 
+		/// <summary>
+		/// Handle of the scene the service's MonoBehaviour belongs to, or -1 for non-MonoBehaviour
+		/// services. Available in all build targets (not just the editor) so scene-based cleanup
+		/// works in player builds.
+		/// </summary>
+		public int SceneHandle { get; set; } = -1;
+
+		/// <summary>
+		/// Whether the service's MonoBehaviour lives in the DontDestroyOnLoad scene.
+		/// Available in all build targets so scene-based cleanup can skip persistent services.
+		/// </summary>
+		public bool IsDontDestroyOnLoad { get; set; }
+
 #if UNITY_EDITOR
 		/// <summary>
 		/// Editor-only debug metadata for ServiceKit Window and debugging

--- a/Runtime/ServiceKitLocator.cs
+++ b/Runtime/ServiceKitLocator.cs
@@ -709,22 +709,7 @@ namespace Nonatomic.ServiceKit
 
 				foreach (var kvp in _readyServices)
 				{
-					var serviceInfo = kvp.Value;
-
-					if (!(serviceInfo.Service is MonoBehaviour))
-						continue;
-
-#if UNITY_EDITOR
-					if (serviceInfo.DebugData.IsDontDestroyOnLoad)
-						continue;
-
-					if (serviceInfo.DebugData.SceneHandle == scene.handle)
-					{
-						servicesToRemove.Add(kvp.Key);
-					}
-					else
-#endif
-					if (serviceInfo.Service is MonoBehaviour mb && mb == null)
+					if (ShouldRemoveOnSceneUnload(kvp.Value, scene))
 					{
 						servicesToRemove.Add(kvp.Key);
 					}
@@ -732,22 +717,7 @@ namespace Nonatomic.ServiceKit
 
 				foreach (var kvp in _registeredServices)
 				{
-					var serviceInfo = kvp.Value.ServiceInfo;
-
-					if (!(serviceInfo.Service is MonoBehaviour))
-						continue;
-
-#if UNITY_EDITOR
-					if (serviceInfo.DebugData.IsDontDestroyOnLoad)
-						continue;
-
-					if (serviceInfo.DebugData.SceneHandle == scene.handle)
-					{
-						servicesToRemove.Add(kvp.Key);
-					}
-					else
-#endif
-					if (serviceInfo.Service is MonoBehaviour mb && mb == null)
+					if (ShouldRemoveOnSceneUnload(kvp.Value.ServiceInfo, scene))
 					{
 						servicesToRemove.Add(kvp.Key);
 					}
@@ -773,6 +743,23 @@ namespace Nonatomic.ServiceKit
 			{
 				tcs.TrySetCanceled();
 			}
+		}
+
+		private static bool ShouldRemoveOnSceneUnload(ServiceInfo serviceInfo, Scene scene)
+		{
+			if (!(serviceInfo.Service is MonoBehaviour))
+				return false;
+
+			// Persistent services survive scene unloads.
+			if (serviceInfo.IsDontDestroyOnLoad)
+				return false;
+
+			// Service belongs to the unloading scene...
+			if (serviceInfo.SceneHandle == scene.handle)
+				return true;
+
+			// ...or its backing MonoBehaviour has already been destroyed.
+			return serviceInfo.Service is MonoBehaviour mb && mb == null;
 		}
 
 		public void CleanupDestroyedServices()
@@ -858,6 +845,21 @@ namespace Nonatomic.ServiceKit
 				info.Tags.AddRange(tags);
 			}
 
+			// Runtime scene metadata (populated in all build targets so scene cleanup works in players).
+			if (service is MonoBehaviour sceneBehaviour && sceneBehaviour != null)
+			{
+				var scene = sceneBehaviour.gameObject.scene;
+				info.SceneHandle = scene.handle;
+
+				// Both DontDestroyOnLoad and addressable scenes have buildIndex == -1,
+				// so we check both name and buildIndex to reduce false positives.
+				info.IsDontDestroyOnLoad = scene.name == "DontDestroyOnLoad" && scene.buildIndex == -1;
+			}
+			else
+			{
+				info.SceneHandle = -1;
+			}
+
 #if UNITY_EDITOR
 			info.DebugData.RegisteredAt = DateTime.Now;
 			info.DebugData.RegisteredBy = registeredBy ?? "Unknown";
@@ -867,11 +869,7 @@ namespace Nonatomic.ServiceKit
 				var scene = monoBehaviour.gameObject.scene;
 				info.DebugData.SceneName = scene.name;
 				info.DebugData.SceneHandle = scene.handle;
-
-				// Check if the object is in the DontDestroyOnLoad scene
-				// Both DontDestroyOnLoad and addressable scenes have buildIndex == -1,
-				// so we check both name and buildIndex to reduce false positives
-				info.DebugData.IsDontDestroyOnLoad = scene.name == "DontDestroyOnLoad" && scene.buildIndex == -1;
+				info.DebugData.IsDontDestroyOnLoad = info.IsDontDestroyOnLoad;
 			}
 			else
 			{

--- a/Tests/EditMode/SceneCleanupTests.cs
+++ b/Tests/EditMode/SceneCleanupTests.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+using Nonatomic.ServiceKit;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Tests.EditMode
+{
+	/// <summary>
+	/// Verifies scene-based cleanup relies on runtime scene metadata (available in player builds),
+	/// not editor-only debug data.
+	/// </summary>
+	[TestFixture]
+	public class SceneCleanupTests
+	{
+		public interface IPlainService { }
+		public class PlainService : IPlainService { }
+
+		public interface ISceneService { }
+		public class SceneMonoService : MonoBehaviour, ISceneService { }
+
+		private ServiceKitLocator _locator;
+
+		[SetUp]
+		public void Setup()
+		{
+			_locator = ScriptableObject.CreateInstance<ServiceKitLocator>();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (_locator == null) return;
+			_locator.ClearServices();
+			Object.DestroyImmediate(_locator);
+			_locator = null;
+		}
+
+		[Test]
+		public void RuntimeSceneHandle_IsPopulatedForMonoBehaviourServices()
+		{
+			var go = new GameObject("SceneService");
+			try
+			{
+				var mb = go.AddComponent<SceneMonoService>();
+				_locator.RegisterAndReadyService<ISceneService>(mb);
+
+				var info = _locator.GetAllServices().First(s => s.ServiceType == typeof(ISceneService));
+				Assert.IsTrue(info.SceneHandle == go.scene.handle && info.SceneHandle != -1,
+					$"Runtime scene handle must be populated for player-build scene cleanup " +
+					$"(expected {go.scene.handle}, got {info.SceneHandle})");
+			}
+			finally
+			{
+				Object.DestroyImmediate(go);
+			}
+		}
+
+		[Test]
+		public void UnregisterServicesFromScene_RemovesSceneServices_KeepsNonSceneServices()
+		{
+			// Non-MonoBehaviour service has no scene and should survive a scene unload.
+			_locator.RegisterAndReadyService<IPlainService>(new PlainService());
+
+			var go = new GameObject("SceneService");
+			try
+			{
+				var mb = go.AddComponent<SceneMonoService>();
+				_locator.RegisterAndReadyService<ISceneService>(mb);
+
+				Assert.IsTrue(_locator.IsServiceRegistered<ISceneService>());
+				Assert.IsTrue(_locator.IsServiceRegistered<IPlainService>());
+
+				_locator.UnregisterServicesFromScene(go.scene);
+
+				Assert.IsFalse(_locator.IsServiceRegistered<ISceneService>(),
+					"MonoBehaviour service in the unloaded scene should be removed");
+				Assert.IsTrue(_locator.IsServiceRegistered<IPlainService>(),
+					"Non-scene service should be retained across scene unload");
+			}
+			finally
+			{
+				Object.DestroyImmediate(go);
+			}
+		}
+	}
+}

--- a/Tests/EditMode/SceneCleanupTests.cs.meta
+++ b/Tests/EditMode/SceneCleanupTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 85f0765558685764ea8097248fdb73c6


### PR DESCRIPTION
## Problem
`UnregisterServicesFromScene` matched services to a scene via `SceneHandle` stored in `ServiceInfo.DebugData`, which is compiled out in player builds (`#if UNITY_EDITOR`). So in a build, scene cleanup degraded to only removing services whose backing MonoBehaviour was already destroyed (fake-null), rather than deterministically matching the unloaded scene — a behavioral divergence between editor and player.

## Fix
- `ServiceInfo` now carries `SceneHandle` and `IsDontDestroyOnLoad` as runtime fields, populated for all build targets in `CreateServiceInfo`.
- `UnregisterServicesFromScene` uses these runtime fields (via a new `ShouldRemoveOnSceneUnload` helper) instead of the editor-only debug data. Editor debug data is still populated for the inspector.

## Tests
- `SceneCleanupTests.RuntimeSceneHandle_IsPopulatedForMonoBehaviourServices` — verifies the runtime handle is populated.
- `SceneCleanupTests.UnregisterServicesFromScene_RemovesSceneServices_KeepsNonSceneServices` — verifies cleanup via the runtime fields (the method no longer has any editor-only path).

Full suites green: EditMode 106/106, PlayMode 7/7.

Note on methodology: this is a build-vs-editor divergence, so a fail-first test isn't possible in the in-editor test runner — the editor path worked in both old and new code. The tests above instead lock in the runtime mechanism the fix introduces (the cleanup method now has no `#if UNITY_EDITOR` branch, so the editor suite genuinely exercises the build path).