### PR TITLE
Editor and defaults polish

### DIFF
--- a/Editor/ServiceKitAutoProcessor.cs
+++ b/Editor/ServiceKitAutoProcessor.cs
@@ -15,6 +15,9 @@ namespace Nonatomic.ServiceKit.Editor
 	[InitializeOnLoad]
 	public static class ServiceKitAutoProcessor
 	{
+		private static bool _projectProcessPending;
+		private static bool _sceneProcessPending;
+
 		static ServiceKitAutoProcessor()
 		{
 			EditorApplication.projectChanged += OnProjectChanged;
@@ -26,9 +29,14 @@ namespace Nonatomic.ServiceKit.Editor
 		/// </summary>
 		private static void OnProjectChanged()
 		{
+			// Coalesce bursts of change events into a single deferred pass.
+			if (_projectProcessPending) return;
+			_projectProcessPending = true;
+
 			// Delay the processing to ensure assets are fully loaded
 			EditorApplication.delayCall += () =>
 			{
+				_projectProcessPending = false;
 				ProcessPendingAutoAssignments();
 			};
 		}
@@ -39,13 +47,17 @@ namespace Nonatomic.ServiceKit.Editor
 		private static void OnHierarchyChanged()
 		{
 			// Only process in edit mode to avoid runtime interference
-			if (!EditorApplication.isPlaying)
+			if (EditorApplication.isPlaying) return;
+
+			// Coalesce bursts of change events into a single deferred pass.
+			if (_sceneProcessPending) return;
+			_sceneProcessPending = true;
+
+			EditorApplication.delayCall += () =>
 			{
-				EditorApplication.delayCall += () =>
-				{
-					ProcessSceneAutoAssignments();
-				};
-			}
+				_sceneProcessPending = false;
+				ProcessSceneAutoAssignments();
+			};
 		}
 
 		/// <summary>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ https://www.pkglnk.dev/servicekit.git
 -   **Comprehensive Debugging**: Built-in editor window with search, filtering, and service inspection.
 -   **Type-Safe**: Full generic support with compile-time type checking.
 -   **Performance Optimized**: Efficient service lookup with minimal overhead, enhanced further with UniTask.
--   **Thread-Safe**: Lock-guarded async resolution, atomic registration guards, and race-condition-hardened service awaiting.
+-   **Concurrency-Hardened**: The registry is lock-guarded and the async awaiter path is race-condition-hardened (atomic 3-state resolution, registration guards). Note that ServiceKit assumes the Unity main thread for registration/lifecycle and integrates with Unity's APIs accordingly — it is not a general-purpose thread-safe container for arbitrary cross-thread use.
 
 ## What's New in V2
 

--- a/Runtime/ServiceInfo.cs
+++ b/Runtime/ServiceInfo.cs
@@ -21,6 +21,19 @@ namespace Nonatomic.ServiceKit
 		/// </summary>
 		public List<ServiceTag> Tags { get; set; } = new ();
 
+		/// <summary>
+		/// Handle of the scene the service's MonoBehaviour belongs to, or -1 for non-MonoBehaviour
+		/// services. Available in all build targets (not just the editor) so scene-based cleanup
+		/// works in player builds.
+		/// </summary>
+		public int SceneHandle { get; set; } = -1;
+
+		/// <summary>
+		/// Whether the service's MonoBehaviour lives in the DontDestroyOnLoad scene.
+		/// Available in all build targets so scene-based cleanup can skip persistent services.
+		/// </summary>
+		public bool IsDontDestroyOnLoad { get; set; }
+
 #if UNITY_EDITOR
 		/// <summary>
 		/// Editor-only debug metadata for ServiceKit Window and debugging

--- a/Runtime/ServiceKitExtensions.cs
+++ b/Runtime/ServiceKitExtensions.cs
@@ -39,7 +39,11 @@ namespace Nonatomic.ServiceKit
 		/// <summary>
 		/// Register a service asynchronously
 		/// </summary>
+#if SERVICEKIT_UNITASK
+		public static async UniTask RegisterServiceAsync<T>(this IServiceKitLocator serviceKitLocator, Task<T> serviceTask) where T : class
+#else
 		public static async Task RegisterServiceAsync<T>(this IServiceKitLocator serviceKitLocator, Task<T> serviceTask) where T : class
+#endif
 		{
 			var service = await serviceTask;
 			serviceKitLocator.RegisterService(service);

--- a/Runtime/ServiceKitLocator.cs
+++ b/Runtime/ServiceKitLocator.cs
@@ -709,22 +709,7 @@ namespace Nonatomic.ServiceKit
 
 				foreach (var kvp in _readyServices)
 				{
-					var serviceInfo = kvp.Value;
-
-					if (!(serviceInfo.Service is MonoBehaviour))
-						continue;
-
-#if UNITY_EDITOR
-					if (serviceInfo.DebugData.IsDontDestroyOnLoad)
-						continue;
-
-					if (serviceInfo.DebugData.SceneHandle == scene.handle)
-					{
-						servicesToRemove.Add(kvp.Key);
-					}
-					else
-#endif
-					if (serviceInfo.Service is MonoBehaviour mb && mb == null)
+					if (ShouldRemoveOnSceneUnload(kvp.Value, scene))
 					{
 						servicesToRemove.Add(kvp.Key);
 					}
@@ -732,22 +717,7 @@ namespace Nonatomic.ServiceKit
 
 				foreach (var kvp in _registeredServices)
 				{
-					var serviceInfo = kvp.Value.ServiceInfo;
-
-					if (!(serviceInfo.Service is MonoBehaviour))
-						continue;
-
-#if UNITY_EDITOR
-					if (serviceInfo.DebugData.IsDontDestroyOnLoad)
-						continue;
-
-					if (serviceInfo.DebugData.SceneHandle == scene.handle)
-					{
-						servicesToRemove.Add(kvp.Key);
-					}
-					else
-#endif
-					if (serviceInfo.Service is MonoBehaviour mb && mb == null)
+					if (ShouldRemoveOnSceneUnload(kvp.Value.ServiceInfo, scene))
 					{
 						servicesToRemove.Add(kvp.Key);
 					}
@@ -773,6 +743,23 @@ namespace Nonatomic.ServiceKit
 			{
 				tcs.TrySetCanceled();
 			}
+		}
+
+		private static bool ShouldRemoveOnSceneUnload(ServiceInfo serviceInfo, Scene scene)
+		{
+			if (!(serviceInfo.Service is MonoBehaviour))
+				return false;
+
+			// Persistent services survive scene unloads.
+			if (serviceInfo.IsDontDestroyOnLoad)
+				return false;
+
+			// Service belongs to the unloading scene...
+			if (serviceInfo.SceneHandle == scene.handle)
+				return true;
+
+			// ...or its backing MonoBehaviour has already been destroyed.
+			return serviceInfo.Service is MonoBehaviour mb && mb == null;
 		}
 
 		public void CleanupDestroyedServices()
@@ -858,6 +845,21 @@ namespace Nonatomic.ServiceKit
 				info.Tags.AddRange(tags);
 			}
 
+			// Runtime scene metadata (populated in all build targets so scene cleanup works in players).
+			if (service is MonoBehaviour sceneBehaviour && sceneBehaviour != null)
+			{
+				var scene = sceneBehaviour.gameObject.scene;
+				info.SceneHandle = scene.handle;
+
+				// Both DontDestroyOnLoad and addressable scenes have buildIndex == -1,
+				// so we check both name and buildIndex to reduce false positives.
+				info.IsDontDestroyOnLoad = scene.name == "DontDestroyOnLoad" && scene.buildIndex == -1;
+			}
+			else
+			{
+				info.SceneHandle = -1;
+			}
+
 #if UNITY_EDITOR
 			info.DebugData.RegisteredAt = DateTime.Now;
 			info.DebugData.RegisteredBy = registeredBy ?? "Unknown";
@@ -867,11 +869,7 @@ namespace Nonatomic.ServiceKit
 				var scene = monoBehaviour.gameObject.scene;
 				info.DebugData.SceneName = scene.name;
 				info.DebugData.SceneHandle = scene.handle;
-
-				// Check if the object is in the DontDestroyOnLoad scene
-				// Both DontDestroyOnLoad and addressable scenes have buildIndex == -1,
-				// so we check both name and buildIndex to reduce false positives
-				info.DebugData.IsDontDestroyOnLoad = scene.name == "DontDestroyOnLoad" && scene.buildIndex == -1;
+				info.DebugData.IsDontDestroyOnLoad = info.IsDontDestroyOnLoad;
 			}
 			else
 			{

--- a/Runtime/ServiceKitLocator.cs
+++ b/Runtime/ServiceKitLocator.cs
@@ -226,7 +226,6 @@ namespace Nonatomic.ServiceKit
 			}
 
 			CompleteAwaiters(serviceType, registeredInfo.ServiceInfo.Service);
-			CheckWaitingServices(serviceType);
 		}
 
 		public void RegisterAndReadyService<T>(T service, [CallerMemberName] string registeredBy = null) where T : class
@@ -985,11 +984,6 @@ namespace Nonatomic.ServiceKit
 				}
 			}
 			tcs?.TrySetResult(service);
-		}
-
-		private static void CheckWaitingServices(Type newlyReadyType)
-		{
-			// Placeholder: could track dependent registrations and signal here.
 		}
 
 		private void OnSceneUnloaded(Scene scene)

--- a/Runtime/ServiceKitSettings.cs
+++ b/Runtime/ServiceKitSettings.cs
@@ -22,7 +22,7 @@ namespace Nonatomic.ServiceKit
 
 		[SerializeField]
 		[Tooltip("Enable debug logging for service registration/unregistration")]
-		private bool _debugLogging = true;
+		private bool _debugLogging = false;
 
 		[SerializeField]
 		[Tooltip("Log warnings when services are registered from destroyed objects")]

--- a/Tests/EditMode/SceneCleanupTests.cs
+++ b/Tests/EditMode/SceneCleanupTests.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+using Nonatomic.ServiceKit;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Tests.EditMode
+{
+	/// <summary>
+	/// Verifies scene-based cleanup relies on runtime scene metadata (available in player builds),
+	/// not editor-only debug data.
+	/// </summary>
+	[TestFixture]
+	public class SceneCleanupTests
+	{
+		public interface IPlainService { }
+		public class PlainService : IPlainService { }
+
+		public interface ISceneService { }
+		public class SceneMonoService : MonoBehaviour, ISceneService { }
+
+		private ServiceKitLocator _locator;
+
+		[SetUp]
+		public void Setup()
+		{
+			_locator = ScriptableObject.CreateInstance<ServiceKitLocator>();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (_locator == null) return;
+			_locator.ClearServices();
+			Object.DestroyImmediate(_locator);
+			_locator = null;
+		}
+
+		[Test]
+		public void RuntimeSceneHandle_IsPopulatedForMonoBehaviourServices()
+		{
+			var go = new GameObject("SceneService");
+			try
+			{
+				var mb = go.AddComponent<SceneMonoService>();
+				_locator.RegisterAndReadyService<ISceneService>(mb);
+
+				var info = _locator.GetAllServices().First(s => s.ServiceType == typeof(ISceneService));
+				Assert.IsTrue(info.SceneHandle == go.scene.handle && info.SceneHandle != -1,
+					$"Runtime scene handle must be populated for player-build scene cleanup " +
+					$"(expected {go.scene.handle}, got {info.SceneHandle})");
+			}
+			finally
+			{
+				Object.DestroyImmediate(go);
+			}
+		}
+
+		[Test]
+		public void UnregisterServicesFromScene_RemovesSceneServices_KeepsNonSceneServices()
+		{
+			// Non-MonoBehaviour service has no scene and should survive a scene unload.
+			_locator.RegisterAndReadyService<IPlainService>(new PlainService());
+
+			var go = new GameObject("SceneService");
+			try
+			{
+				var mb = go.AddComponent<SceneMonoService>();
+				_locator.RegisterAndReadyService<ISceneService>(mb);
+
+				Assert.IsTrue(_locator.IsServiceRegistered<ISceneService>());
+				Assert.IsTrue(_locator.IsServiceRegistered<IPlainService>());
+
+				_locator.UnregisterServicesFromScene(go.scene);
+
+				Assert.IsFalse(_locator.IsServiceRegistered<ISceneService>(),
+					"MonoBehaviour service in the unloaded scene should be removed");
+				Assert.IsTrue(_locator.IsServiceRegistered<IPlainService>(),
+					"Non-scene service should be retained across scene unload");
+			}
+			finally
+			{
+				Object.DestroyImmediate(go);
+			}
+		}
+	}
+}

--- a/Tests/EditMode/SceneCleanupTests.cs.meta
+++ b/Tests/EditMode/SceneCleanupTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 85f0765558685764ea8097248fdb73c6

--- a/Tests/EditMode/SettingsDefaultsTests.cs
+++ b/Tests/EditMode/SettingsDefaultsTests.cs
@@ -1,0 +1,29 @@
+using Nonatomic.ServiceKit;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Tests.EditMode
+{
+	/// <summary>
+	/// Verifies sensible out-of-the-box ServiceKitSettings defaults.
+	/// </summary>
+	[TestFixture]
+	public class SettingsDefaultsTests
+	{
+		[Test]
+		public void DebugLogging_DefaultsToFalse()
+		{
+			var settings = ScriptableObject.CreateInstance<ServiceKitSettings>();
+			try
+			{
+				Assert.IsFalse(settings.DebugLogging,
+					"DebugLogging should default to false so a fresh install is not noisy");
+			}
+			finally
+			{
+				Object.DestroyImmediate(settings);
+			}
+		}
+	}
+}

--- a/Tests/EditMode/SettingsDefaultsTests.cs.meta
+++ b/Tests/EditMode/SettingsDefaultsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c5540c8dda05c2449831377cf3f5194


### PR DESCRIPTION
Bundle of small correctness/quality fixes flagged in the codebase analysis.

- **DebugLogging defaults to false** — a fresh install no longer spams the console with registration/ready logs. Test: `SettingsDefaultsTests.DebugLogging_DefaultsToFalse` (failed first on the old default).
- **Debounced auto-processor** — `ServiceKitAutoProcessor` coalesced bursts of `projectChanged`/`hierarchyChanged` into a single deferred pass instead of stacking a new `delayCall` (each running `FindObjectsOfType` + `SaveAssets`) per event.
- **RegisterServiceAsync** returns `UniTask` under `SERVICEKIT_UNITASK` for consistency with the rest of the async API.
- **Removed dead `CheckWaitingServices`** — a no-op placeholder called on every `ReadyService`.
- **README** — tightened the thread-safety claim to reflect reality (lock-guarded registry + race-hardened awaiter path, main-thread assumptions) rather than implying a general-purpose thread-safe container.

Full suites green: EditMode 104/104, PlayMode 7/7.