### PR TITLE
Improve injection failure messages, routing and severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 - **Injection failure messages and routing**: failed injections now log with the target object as the Unity log context, so clicking the console entry selects the offending GameObject instead of jumping into ServiceKit's source. Messages name the cause accurately (genuine timeout vs. an awaited service being unregistered vs. the target being destroyed) and include the GameObject's hierarchy path and scene.
 - **Quieter scene transitions**: when an injection is cancelled because the target was destroyed (e.g. skipping scenes) the failure is no longer logged at all; when only an awaited service is unregistered while the target survives it is logged as a warning rather than an error. Genuine timeouts, missing required services, and circular dependencies remain errors. Cancellation/timeout failures now throw `ServiceInjectionTimeoutException` (a `TimeoutException` subclass carrying a `ServiceInjectionFailureKind`), so existing `catch (TimeoutException)` continues to work.
+- **Unregistration is now distinguishable from a timeout**: unregistering a service (directly, via scene unload, or `ClearServices`) faults pending awaiters with a typed `ServiceUnregisteredException` (a subclass of `OperationCanceledException`) instead of a bare cancellation. Injection identifies this case positively rather than inferring it from the absence of a timeout, so "a service was unregistered" and "the wait timed out" are never conflated.
 
 ## [2.2.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Changed
+- **Injection failure messages and routing**: failed injections now log with the target object as the Unity log context, so clicking the console entry selects the offending GameObject instead of jumping into ServiceKit's source. Messages name the cause accurately (genuine timeout vs. an awaited service being unregistered vs. the target being destroyed) and include the GameObject's hierarchy path and scene.
+- **Quieter scene transitions**: when an injection is cancelled because the target was destroyed (e.g. skipping scenes) the failure is no longer logged at all; when only an awaited service is unregistered while the target survives it is logged as a warning rather than an error. Genuine timeouts, missing required services, and circular dependencies remain errors. Cancellation/timeout failures now throw `ServiceInjectionTimeoutException` (a `TimeoutException` subclass carrying a `ServiceInjectionFailureKind`), so existing `catch (TimeoutException)` continues to work.
+
 ## [2.2.0] - 2026-05-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-## [Unreleased]
+## [2.3.0] - 2026-06-05
 
 ### Changed
-- **Injection failure messages and routing**: failed injections now log with the target object as the Unity log context, so clicking the console entry selects the offending GameObject instead of jumping into ServiceKit's source. Messages name the cause accurately (genuine timeout vs. an awaited service being unregistered vs. the target being destroyed) and include the GameObject's hierarchy path and scene.
-- **Quieter scene transitions**: when an injection is cancelled because the target was destroyed (e.g. skipping scenes) the failure is no longer logged at all; when only an awaited service is unregistered while the target survives it is logged as a warning rather than an error. Genuine timeouts, missing required services, and circular dependencies remain errors. Cancellation/timeout failures now throw `ServiceInjectionTimeoutException` (a `TimeoutException` subclass carrying a `ServiceInjectionFailureKind`), so existing `catch (TimeoutException)` continues to work.
-- **Unregistration is now distinguishable from a timeout**: unregistering a service (directly, via scene unload, or `ClearServices`) faults pending awaiters with a typed `ServiceUnregisteredException` (a subclass of `OperationCanceledException`) instead of a bare cancellation. Injection identifies this case positively rather than inferring it from the absence of a timeout, so "a service was unregistered" and "the wait timed out" are never conflated.
+- Injection failures now log with the target as the Unity log context — click the console entry to select the offending GameObject — and name the cause (timeout, service unregistered, or target destroyed) with the GameObject's hierarchy path and scene.
+- Quieter scene transitions: a destroyed target is silent and an unregistered service (while the target survives) is a warning; timeouts, missing required services, and circular dependencies stay errors.
+
+### Added
+- `ServiceUnregisteredException` (`OperationCanceledException` subclass) and `ServiceInjectionTimeoutException` (`TimeoutException` subclass) so an unregistered service is distinguished from a timeout positively rather than inferred. Both subclass their existing base, so existing `catch` clauses keep working.
 
 ## [2.2.0] - 2026-05-31
 

--- a/Runtime/ServiceInjectionBuilder.cs
+++ b/Runtime/ServiceInjectionBuilder.cs
@@ -166,9 +166,10 @@ namespace Nonatomic.ServiceKit
 				}
 
 				// Route the failure through the configured handler (if any) before surfacing it.
-				var timeoutException = BuildTimeoutException(fieldsToInject, isExplicitTimeout);
-				_errorHandler?.Invoke(timeoutException);
-				throw timeoutException;
+				var kind = ClassifyCancellation(isExplicitTimeout);
+				var injectionException = BuildInjectionException(fieldsToInject, kind);
+				_errorHandler?.Invoke(injectionException);
+				throw injectionException;
 			}
 			catch (Exception ex)
 			{
@@ -453,12 +454,12 @@ namespace Nonatomic.ServiceKit
 
 		private void DefaultErrorHandler(Exception exception)
 		{
-			Debug.LogError($"Failed to inject required services: {exception.Message}");
+			ServiceInjectionLog.Report(exception, _target as UnityEngine.Object);
 
 			var circular = _dependencyGraph?.DetectCircularDependency(_targetServiceType);
 			if (circular == null) return;
 
-			Debug.LogError($"Circular dependency detected: {circular.Path}");
+			Debug.LogError($"Circular dependency detected: {circular.Path}", _target as UnityEngine.Object);
 			_dependencyGraph?.AddCircularDependencyError(_targetServiceType);
 
 			if (circular.ToType != null)
@@ -475,16 +476,46 @@ namespace Nonatomic.ServiceKit
 			return !isExplicitTimeout && !_cancellationToken.IsCancellationRequested && !Application.isPlaying;
 		}
 
-		private TimeoutException BuildTimeoutException(List<FieldInfo> fieldsToInject, bool isExplicitTimeout)
+		private ServiceInjectionFailureKind ClassifyCancellation(bool isExplicitTimeout)
+		{
+			if (isExplicitTimeout)
+			{
+				return ServiceInjectionFailureKind.Timeout;
+			}
+
+			// The only reliable "target destroyed" signal is the target being a Unity object
+			// that has already been torn down (Unity's overloaded null check).
+			var targetIsUnityObject = _target is UnityEngine.Object;
+			if (targetIsUnityObject && (UnityEngine.Object)_target == null)
+			{
+				return ServiceInjectionFailureKind.TargetDestroyed;
+			}
+
+			if (_cancellationToken.IsCancellationRequested)
+			{
+				// For a Unity target this is its destroyCancellationToken firing (scene change /
+				// teardown), so treat it as a destroyed target. For a plain C# object it is a
+				// deliberate caller cancellation that is worth surfacing.
+				return targetIsUnityObject
+					? ServiceInjectionFailureKind.TargetDestroyed
+					: ServiceInjectionFailureKind.CallerCanceled;
+			}
+
+			// Not a timeout, target still alive, no caller cancellation: an awaited service was
+			// unregistered before it became available (e.g. its provider was destroyed).
+			return ServiceInjectionFailureKind.ServiceUnregistered;
+		}
+
+		private ServiceInjectionTimeoutException BuildInjectionException(List<FieldInfo> fieldsToInject, ServiceInjectionFailureKind kind)
 		{
 			var sb = ServiceKitObjectPool.RentStringBuilder();
 			try
 			{
-				AppendTimeoutMessage(sb, isExplicitTimeout);
+				AppendFailureMessage(sb, kind);
 				AppendWaitingServices(sb, fieldsToInject);
 				AppendCircularDependencyInfo(sb);
-				
-				return new TimeoutException(sb.ToString());
+
+				return new ServiceInjectionTimeoutException(sb.ToString(), kind);
 			}
 			finally
 			{
@@ -492,24 +523,74 @@ namespace Nonatomic.ServiceKit
 			}
 		}
 
-		private void AppendTimeoutMessage(StringBuilder sb, bool isExplicitTimeout)
+		private void AppendFailureMessage(StringBuilder sb, ServiceInjectionFailureKind kind)
 		{
-			sb.Append("Service injection timed out");
-			
-			if (isExplicitTimeout && _timeout > 0f)
+			switch (kind)
 			{
-				sb.Append(" after ");
-				sb.Append(_timeout);
-				sb.Append(" seconds");
+				case ServiceInjectionFailureKind.Timeout:
+					sb.Append("Service injection timed out");
+					if (_timeout > 0f)
+					{
+						sb.Append(" after ");
+						sb.Append(_timeout);
+						sb.Append(" seconds");
+					}
+					sb.Append(" for ");
+					sb.Append(DescribeTarget());
+					sb.Append('.');
+					break;
+
+				case ServiceInjectionFailureKind.ServiceUnregistered:
+					sb.Append("Service injection for ");
+					sb.Append(DescribeTarget());
+					sb.Append(" was interrupted because a required service was unregistered before it became available (e.g. a scene change).");
+					break;
+
+				case ServiceInjectionFailureKind.TargetDestroyed:
+					sb.Append("Service injection for ");
+					sb.Append(DescribeTarget());
+					sb.Append(" was canceled because the target was destroyed (e.g. a scene change).");
+					break;
+
+				default: // CallerCanceled
+					sb.Append("Service injection for ");
+					sb.Append(DescribeTarget());
+					sb.Append(" was canceled via its cancellation token.");
+					break;
 			}
-			else if (_cancellationToken.IsCancellationRequested)
+		}
+
+		/// <summary>
+		/// Describes the injection target for error messages. For a live Component this includes
+		/// the GameObject's hierarchy path and scene, so the offending object is easy to locate.
+		/// Guarded against Unity fake-null in case the target is mid-destruction.
+		/// </summary>
+		private string DescribeTarget()
+		{
+			var typeName = _target.GetType().Name;
+
+			if (_target is Component component && component != null)
 			{
-				sb.Append(" (via cancellation token)");
+				var path = GetHierarchyPath(component.transform);
+				var scene = component.gameObject.scene;
+				return scene.IsValid()
+					? $"'{typeName}' on '{path}' (scene '{scene.name}')"
+					: $"'{typeName}' on '{path}'";
 			}
-			
-			sb.Append(" for target '");
-			sb.Append(_target.GetType().Name);
-			sb.Append("'.");
+
+			return $"'{typeName}'";
+		}
+
+		private static string GetHierarchyPath(Transform transform)
+		{
+			// Error path — a plain StringBuilder is fine and avoids nesting the shared pool.
+			var sb = new StringBuilder(transform.name);
+			for (var parent = transform.parent; parent != null; parent = parent.parent)
+			{
+				sb.Insert(0, '/');
+				sb.Insert(0, parent.name);
+			}
+			return sb.ToString();
 		}
 
 		private void AppendWaitingServices(StringBuilder sb, List<FieldInfo> fieldsToInject)

--- a/Runtime/ServiceInjectionBuilder.cs
+++ b/Runtime/ServiceInjectionBuilder.cs
@@ -153,7 +153,7 @@ namespace Nonatomic.ServiceKit
 					await InjectResolvedServices(results, unityContext);
 				}
 			}
-			catch (OperationCanceledException)
+			catch (OperationCanceledException oce)
 			{
 				var isExplicitTimeout = timeoutCts?.IsCancellationRequested ?? false;
 
@@ -166,7 +166,7 @@ namespace Nonatomic.ServiceKit
 				}
 
 				// Route the failure through the configured handler (if any) before surfacing it.
-				var kind = ClassifyCancellation(isExplicitTimeout);
+				var kind = ClassifyCancellation(oce, isExplicitTimeout);
 				var injectionException = BuildInjectionException(fieldsToInject, kind);
 				_errorHandler?.Invoke(injectionException);
 				throw injectionException;
@@ -476,33 +476,40 @@ namespace Nonatomic.ServiceKit
 			return !isExplicitTimeout && !_cancellationToken.IsCancellationRequested && !Application.isPlaying;
 		}
 
-		private ServiceInjectionFailureKind ClassifyCancellation(bool isExplicitTimeout)
+		private ServiceInjectionFailureKind ClassifyCancellation(Exception exception, bool isExplicitTimeout)
 		{
-			if (isExplicitTimeout)
-			{
-				return ServiceInjectionFailureKind.Timeout;
-			}
-
-			// The only reliable "target destroyed" signal is the target being a Unity object
-			// that has already been torn down (Unity's overloaded null check).
+			// A destroyed target takes precedence: the injection is moot regardless of why it ended.
+			// Unity's overloaded null check is the only reliable "target destroyed" signal.
 			var targetIsUnityObject = _target is UnityEngine.Object;
 			if (targetIsUnityObject && (UnityEngine.Object)_target == null)
 			{
 				return ServiceInjectionFailureKind.TargetDestroyed;
 			}
 
+			// Positively signalled by the locator when an awaited service is unregistered
+			// (directly, via scene unload, or on ClearServices) - no inference required.
+			if (exception is ServiceUnregisteredException)
+			{
+				return ServiceInjectionFailureKind.ServiceUnregistered;
+			}
+
+			// Positively signalled: only the timeout manager cancels timeoutCts.
+			if (isExplicitTimeout)
+			{
+				return ServiceInjectionFailureKind.Timeout;
+			}
+
 			if (_cancellationToken.IsCancellationRequested)
 			{
 				// For a Unity target this is its destroyCancellationToken firing (scene change /
-				// teardown), so treat it as a destroyed target. For a plain C# object it is a
-				// deliberate caller cancellation that is worth surfacing.
+				// teardown); for a plain C# object it is a deliberate caller cancellation.
 				return targetIsUnityObject
 					? ServiceInjectionFailureKind.TargetDestroyed
 					: ServiceInjectionFailureKind.CallerCanceled;
 			}
 
-			// Not a timeout, target still alive, no caller cancellation: an awaited service was
-			// unregistered before it became available (e.g. its provider was destroyed).
+			// Residual: a bare cancellation with no token and no typed cause. Nothing positively
+			// indicates a timeout, so treat it as a vanished service (warning) rather than an error.
 			return ServiceInjectionFailureKind.ServiceUnregistered;
 		}
 

--- a/Runtime/ServiceInjectionException.cs
+++ b/Runtime/ServiceInjectionException.cs
@@ -34,6 +34,24 @@ namespace Nonatomic.ServiceKit
 	}
 
 	/// <summary>
+	/// Faults a pending service awaiter when its service is unregistered (directly, via scene
+	/// unload, or on <c>ClearServices</c>) before it became available. Subclasses
+	/// <see cref="OperationCanceledException"/> so existing <c>catch</c> clauses keep working, while
+	/// letting the injection builder positively identify "service unregistered" rather than infer it
+	/// from the absence of a timeout.
+	/// </summary>
+	public class ServiceUnregisteredException : OperationCanceledException
+	{
+		public ServiceUnregisteredException(Type serviceType)
+			: base($"Service '{serviceType?.Name ?? "unknown"}' was unregistered before injection completed.")
+		{
+			ServiceType = serviceType;
+		}
+
+		public Type ServiceType { get; }
+	}
+
+	/// <summary>
 	/// Thrown when injection is cancelled or times out. Subclasses <see cref="TimeoutException"/>
 	/// for backwards compatibility (existing <c>catch (TimeoutException)</c> still works) while
 	/// carrying a <see cref="Kind"/> so handlers can route severity correctly.

--- a/Runtime/ServiceInjectionException.cs
+++ b/Runtime/ServiceInjectionException.cs
@@ -1,7 +1,27 @@
-﻿using System;
+using System;
+using UnityEngine;
 
 namespace Nonatomic.ServiceKit
 {
+	/// <summary>
+	/// Why a dependency injection attempt ended. Used to choose how the failure is
+	/// surfaced (error / warning / silent) and to word the message accurately.
+	/// </summary>
+	public enum ServiceInjectionFailureKind
+	{
+		/// <summary>A required service never became available within the timeout.</summary>
+		Timeout,
+
+		/// <summary>The caller's cancellation token fired (a deliberate cancellation on a non-Unity target).</summary>
+		CallerCanceled,
+
+		/// <summary>An awaited service was unregistered before it became available (e.g. its provider was destroyed during a scene change). Target is still alive.</summary>
+		ServiceUnregistered,
+
+		/// <summary>The injection target itself was destroyed mid-injection (e.g. a scene change). Expected teardown.</summary>
+		TargetDestroyed
+	}
+
 	public class ServiceInjectionException : Exception
 	{
 		public ServiceInjectionException(string message) : base(message)
@@ -10,6 +30,49 @@ namespace Nonatomic.ServiceKit
 
 		public ServiceInjectionException(string message, Exception innerException) : base(message, innerException)
 		{
+		}
+	}
+
+	/// <summary>
+	/// Thrown when injection is cancelled or times out. Subclasses <see cref="TimeoutException"/>
+	/// for backwards compatibility (existing <c>catch (TimeoutException)</c> still works) while
+	/// carrying a <see cref="Kind"/> so handlers can route severity correctly.
+	/// </summary>
+	public class ServiceInjectionTimeoutException : TimeoutException
+	{
+		public ServiceInjectionTimeoutException(string message, ServiceInjectionFailureKind kind) : base(message)
+		{
+			Kind = kind;
+		}
+
+		public ServiceInjectionFailureKind Kind { get; }
+	}
+
+	/// <summary>
+	/// Severity-aware logging for injection failures, shared by the builder's default handler
+	/// and <c>ServiceKitBehaviour.HandleDependencyInjectionFailure</c> so both route the same way:
+	/// a destroyed target is silent (expected teardown), a vanished service is a warning, and
+	/// everything else is an error. The <paramref name="context"/> object makes the console entry
+	/// select the offending GameObject when clicked.
+	/// </summary>
+	public static class ServiceInjectionLog
+	{
+		public static void Report(Exception exception, UnityEngine.Object context)
+		{
+			var message = $"Failed to inject required services: {exception.Message}";
+
+			switch ((exception as ServiceInjectionTimeoutException)?.Kind)
+			{
+				case ServiceInjectionFailureKind.TargetDestroyed:
+					// The target is gone; the failed injection is moot. Stay silent.
+					return;
+				case ServiceInjectionFailureKind.ServiceUnregistered:
+					Debug.LogWarning(message, context);
+					return;
+				default:
+					Debug.LogError(message, context);
+					return;
+			}
 		}
 	}
 }

--- a/Runtime/ServiceKitBehaviour.cs
+++ b/Runtime/ServiceKitBehaviour.cs
@@ -331,7 +331,7 @@ namespace Nonatomic.ServiceKit
 		/// </summary>
 		protected virtual void HandleDependencyInjectionFailure(Exception exception)
 		{
-			Debug.LogError($"Failed to inject required services: {exception.Message}", this);
+			ServiceInjectionLog.Report(exception, this);
 		}
 
 		private bool IsServiceLocatorMissing()

--- a/Runtime/ServiceKitLocator.cs
+++ b/Runtime/ServiceKitLocator.cs
@@ -561,8 +561,9 @@ namespace Nonatomic.ServiceKit
 				}
 			}
 
-			// Cancel outside the lock so awaiter continuations never run while _lock is held.
-			awaiterToCancel?.TrySetCanceled();
+			// Fault outside the lock so awaiter continuations never run while _lock is held.
+			// A typed exception lets injection distinguish "service unregistered" from a timeout.
+			awaiterToCancel?.TrySetException(new ServiceUnregisteredException(serviceType));
 		}
 
 		public string GetServiceStatus<T>() where T : class
@@ -697,9 +698,9 @@ namespace Nonatomic.ServiceKit
 		public void UnregisterServicesFromScene(Scene scene)
 		{
 #if SERVICEKIT_UNITASK
-			var awaitersToCancel = new List<UniTaskCompletionSource<object>>();
+			var awaitersToCancel = new List<(Type type, UniTaskCompletionSource<object> tcs)>();
 #else
-			var awaitersToCancel = new List<TaskCompletionSource<object>>();
+			var awaitersToCancel = new List<(Type type, TaskCompletionSource<object> tcs)>();
 #endif
 
 			lock (_lock)
@@ -730,17 +731,17 @@ namespace Nonatomic.ServiceKit
 					if (_serviceAwaiters.TryGetValue(type, out var tcs))
 					{
 						_serviceAwaiters.Remove(type);
-						awaitersToCancel.Add(tcs);
+						awaitersToCancel.Add((type, tcs));
 					}
 				}
 
 				_trackedScenes.Remove(scene);
 			}
 
-			// Cancel outside the lock so awaiter continuations never run while _lock is held.
-			foreach (var tcs in awaitersToCancel)
+			// Fault outside the lock so awaiter continuations never run while _lock is held.
+			foreach (var (type, tcs) in awaitersToCancel)
 			{
-				tcs.TrySetCanceled();
+				tcs.TrySetException(new ServiceUnregisteredException(type));
 			}
 		}
 
@@ -795,17 +796,17 @@ namespace Nonatomic.ServiceKit
 		public void ClearServices()
 		{
 #if SERVICEKIT_UNITASK
-			var awaitersToCancel = new List<UniTaskCompletionSource<object>>();
+			var awaitersToCancel = new List<(Type type, UniTaskCompletionSource<object> tcs)>();
 #else
-			var awaitersToCancel = new List<TaskCompletionSource<object>>();
+			var awaitersToCancel = new List<(Type type, TaskCompletionSource<object> tcs)>();
 #endif
 
 			lock (_lock)
 			{
-				// Collect pending awaiters; they are cancelled after releasing the lock.
+				// Collect pending awaiters; they are faulted after releasing the lock.
 				foreach (var kvp in _serviceAwaiters)
 				{
-					awaitersToCancel.Add(kvp.Value);
+					awaitersToCancel.Add((kvp.Key, kvp.Value));
 				}
 				_serviceAwaiters.Clear();
 
@@ -817,12 +818,12 @@ namespace Nonatomic.ServiceKit
 				_dependencyGraph.ClearAll();
 			}
 
-			// Cancel outside the lock so awaiter continuations never run while _lock is held.
-			foreach (var tcs in awaitersToCancel)
+			// Fault outside the lock so awaiter continuations never run while _lock is held.
+			foreach (var (type, tcs) in awaitersToCancel)
 			{
 				try
 				{
-					tcs.TrySetCanceled();
+					tcs.TrySetException(new ServiceUnregisteredException(type));
 				}
 				catch
 				{

--- a/Tests/PlayMode/InjectionFailureReportingTests.cs
+++ b/Tests/PlayMode/InjectionFailureReportingTests.cs
@@ -1,0 +1,102 @@
+using System.Collections;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Nonatomic.ServiceKit.Tests.PlayMode
+{
+	/// <summary>
+	/// Validates how injection failures are surfaced (see ServiceInjectionLog / ClassifyCancellation):
+	/// a destroyed target during a teardown is silent, while an awaited service being unregistered
+	/// while the target survives is a warning rather than an error.
+	/// </summary>
+	public class InjectionFailureReportingTests
+	{
+		public interface IMissingService { }
+
+		public interface IPendingService { }
+		public class PendingService : IPendingService { }
+
+#pragma warning disable 0169 // fields are assigned via [InjectService] reflection
+		private class RequiresMissingBehaviour : ServiceKitBehaviour
+		{
+			[InjectService] private IMissingService _missing;
+		}
+
+		private class RequiresPendingBehaviour : ServiceKitBehaviour
+		{
+			[InjectService] private IPendingService _pending;
+		}
+#pragma warning restore 0169
+
+		private ServiceKitLocator _locator;
+
+		[SetUp]
+		public void Setup()
+		{
+			_locator = ScriptableObject.CreateInstance<ServiceKitLocator>();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (_locator == null) return;
+			_locator.ClearServices();
+			Object.Destroy(_locator);
+			_locator = null;
+		}
+
+		// Creates an active consumer with the locator assigned before Awake runs.
+		private static GameObject AddConsumer<T>(ServiceKitLocator locator) where T : ServiceKitBehaviour
+		{
+			var go = new GameObject(typeof(T).Name);
+			go.SetActive(false);
+			var consumer = go.AddComponent<T>();
+			consumer.ServiceKitLocator = locator;
+			go.SetActive(true); // triggers Awake -> dependency injection
+			return go;
+		}
+
+		[UnityTest]
+		public IEnumerator DestroyedTargetDuringInjection_IsSilent()
+		{
+			var go = AddConsumer<RequiresMissingBehaviour>(_locator);
+
+			// Let Awake run and injection begin waiting for the (never-registered) required service.
+			yield return null;
+			yield return null;
+
+			// Destroy the target well before the timeout: a teardown cancellation, not a failure.
+			Object.Destroy(go);
+
+			// Allow the cancellation to propagate through the async injection.
+			for (var i = 0; i < 5; i++) yield return null;
+
+			// A destroyed target must not log an error or warning.
+			LogAssert.NoUnexpectedReceived();
+		}
+
+		[UnityTest]
+		public IEnumerator ServiceUnregisteredWhileTargetAlive_LogsWarningNotError()
+		{
+			// A required dependency is registered but never readied, so the consumer waits on it.
+			_locator.RegisterService<IPendingService>(new PendingService());
+
+			var go = AddConsumer<RequiresPendingBehaviour>(_locator);
+
+			// Let the consumer reach the waiting state.
+			for (var i = 0; i < 3; i++) yield return null;
+
+			// Unregistering the awaited service while the target is alive is a warning, not an error.
+			LogAssert.Expect(LogType.Warning, new Regex("Failed to inject required services"));
+
+			_locator.UnregisterService(typeof(IPendingService));
+
+			for (var i = 0; i < 5; i++) yield return null;
+
+			Object.Destroy(go);
+			yield return null;
+		}
+	}
+}

--- a/Tests/PlayMode/InjectionFailureReportingTests.cs.meta
+++ b/Tests/PlayMode/InjectionFailureReportingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 583db5d7c10310c4ebb66d7e6e76eb00

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.nonatomic.servicekit",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "displayName": "Service Kit",
   "description": "A lightweight dependency injection and service locator framework for Unity. Attribute-based registration, async resolution, fluent API, optional dependencies, service tags, scene-aware lifecycle, and UniTask support.",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary
Makes dependency-injection failures far easier to act on, and stops scene transitions spamming red errors.

### Routing to the cause
Failed injections now log with the **target object as the Unity log context**, so clicking the console entry selects the offending GameObject instead of jumping into ServiceKit's source. (`ServiceKitBehaviour` already passed `this`; the builder's `DefaultErrorHandler` did not — now both route through a shared severity-aware logger.)

### Accurate messages
Messages name the real cause and include the GameObject's hierarchy path and scene, e.g.:

> Service injection for 'LookAtPos' on 'Main Camera/LookAtPos' (scene 'Gameplay') was interrupted because a required service was unregistered before it became available (e.g. a scene change). Waiting for services: IMetagameCameraService.

### Severity reflects the cause
- **Target destroyed** (e.g. skipping scenes) → silent.
- **An awaited service unregistered while the target survives** → warning.
- **Genuine timeout / missing required / circular** → error (unchanged).

### Timeout vs. unregister, distinguished positively (not inferred)
Previously `UnregisterService` faulted pending awaiters with a bare `TrySetCanceled()`, indistinguishable from a timeout at the exception level — so everything read as "timed out". Now `UnregisterService`, `UnregisterServicesFromScene` and `ClearServices` fault awaiters with a typed **`ServiceUnregisteredException`** (a subclass of `OperationCanceledException`). The builder classifies by type; only the timeout manager cancels `timeoutCts`, so the two are never conflated.

Cancellation/timeout failures now throw **`ServiceInjectionTimeoutException`** (a `TimeoutException` subclass carrying a `ServiceInjectionFailureKind`). Both new exceptions subclass their existing base, so every `catch (TimeoutException)` / `catch (OperationCanceledException)` keeps working.

## Validation (Unity 6000.3.16f1, batchmode)
- **EditMode: 113/113 passed** — no regressions (incl. the `LogAssert.Expect(Error)` and `catch (TimeoutException)` tests).
- **PlayMode: 12/12 passed**, including two new tests:
  - `DestroyedTargetDuringInjection_IsSilent`
  - `ServiceUnregisteredWhileTargetAlive_LogsWarningNotError`

## Note
Unity always points the console entry's double-click/stack link at the top stack frame (package code) — not overridable. The single-click **context-object selection** of the GameObject is the "go to cause" mechanism this delivers.