### PR TITLE
Make alternative IServiceKitLocator implementations work end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [Unreleased]
+
+### Added
+- `TryResolveService`, `HasCircularDependencyError`, and the `ServiceResolutionStatus` enum are now part of `IServiceKitLocator`, and `ServiceKitBehaviour` exposes a `protected virtual ResolveLocator()` hook. Alternative `IServiceKitLocator` implementations now work end-to-end — including optional-dependency injection, which previously silently no-opped against any non-concrete locator.
+- A package `link.xml` preserving the `[Service]`/`[InjectService]` attribute types for IL2CPP managed stripping.
+
+### Changed
+- Injectable-field and attribute reflection is memoized per type, removing the `GetFields`/LINQ/`GetCustomAttribute` work that previously ran on every injection and registration.
+
+### Removed
+- The unused Unity Test Framework reference is no longer a runtime dependency (dropped from the runtime asmdef and `package.json`), so it no longer ships into player/IL2CPP builds.
+
+> `IServiceKitLocator` gained members — custom implementers of the interface (rare) must add them. Intended for a 2.4.0 release.
+
 ## [2.3.0] - 2026-06-05
 
 ### Changed

--- a/Runtime/IServiceKitLocator.cs
+++ b/Runtime/IServiceKitLocator.cs
@@ -43,6 +43,9 @@ namespace Nonatomic.ServiceKit
 		bool IsServiceReady(Type serviceType);
 		bool IsServiceCircularDependencyExempt<T>() where T : class;
 		bool IsServiceCircularDependencyExempt(Type serviceType);
+		bool HasCircularDependencyError<T>() where T : class;
+		bool HasCircularDependencyError(Type serviceType);
+		ServiceResolutionStatus TryResolveService(Type serviceType, out object service);
 		string GetServiceStatus<T>() where T : class;
 		string GetServiceStatus(Type serviceType);
 		

--- a/Runtime/ServiceInjectionBuilder.cs
+++ b/Runtime/ServiceInjectionBuilder.cs
@@ -22,15 +22,20 @@ namespace Nonatomic.ServiceKit
 	public class ServiceInjectionBuilder : IServiceInjectionBuilder
 	{
 		public ServiceInjectionBuilder(IServiceKitLocator serviceKitLocator, object target)
+			// Fallback for external callers: only the concrete locator owns a dependency graph.
+			: this(serviceKitLocator, target, (serviceKitLocator as ServiceKitLocator)?.DependencyGraph)
+		{
+		}
+
+		// The concrete locator passes its graph in directly (see ServiceKitLocator.Inject) rather than
+		// having it re-discovered via a downcast. An alternative IServiceKitLocator simply has no graph
+		// and circular-dependency bookkeeping is skipped.
+		internal ServiceInjectionBuilder(IServiceKitLocator serviceKitLocator, object target, ServiceDependencyGraph dependencyGraph)
 		{
 			_serviceKitLocator = serviceKitLocator;
 			_target = target;
 			_targetServiceType = DetermineServiceType(target);
-
-			// The dependency graph is owned by the concrete locator. When the locator is a
-			// mock/stub (e.g. in unit tests) there is no graph and circular-dependency
-			// bookkeeping is simply skipped.
-			_dependencyGraph = (serviceKitLocator as ServiceKitLocator)?.DependencyGraph;
+			_dependencyGraph = dependencyGraph;
 		}
 
 		public IServiceInjectionBuilder WithCancellation(CancellationToken cancellationToken)
@@ -354,11 +359,8 @@ namespace Nonatomic.ServiceKit
 		private async Task<(FieldInfo field, object service, bool required)> ResolveOptionalService(FieldInfo field, Type serviceType, InjectServiceAttribute serviceAttribute, CancellationToken cancellationToken, CancellationTokenSource resolutionCts)
 #endif
 		{
-			var locator = _serviceKitLocator as ServiceKitLocator;
-			if (locator == null) return (field, null, serviceAttribute.Required);
-
 			// Atomic check: determines if the service is ready, registered-but-not-ready, or absent
-			var status = locator.TryResolveService(serviceType, out var readyService);
+			var status = _serviceKitLocator.TryResolveService(serviceType, out var readyService);
 
 			if (status == ServiceResolutionStatus.Ready)
 			{
@@ -371,7 +373,7 @@ namespace Nonatomic.ServiceKit
 				await WaitForAwakePhaseCompletion();
 
 				// Re-check atomically after the yield
-				status = locator.TryResolveService(serviceType, out readyService);
+				status = _serviceKitLocator.TryResolveService(serviceType, out readyService);
 
 				if (status == ServiceResolutionStatus.Ready)
 				{
@@ -592,15 +594,14 @@ namespace Nonatomic.ServiceKit
 		private void AppendWaitingServices(StringBuilder sb, List<FieldInfo> fieldsToInject)
 		{
 			var hasMissing = false;
-			var locator = _serviceKitLocator as ServiceKitLocator;
-			
+
 			for (var i = 0; i < fieldsToInject.Count; i++)
 			{
 				var field = fieldsToInject[i];
 				var attr = ServiceKitReflectionCache.GetInjectAttribute(field);
 				var serviceType = field.FieldType;
 				
-				if (IsServiceMissing(serviceType, attr.Required, locator))
+				if (IsServiceMissing(serviceType, attr.Required))
 				{
 					if (!hasMissing)
 					{
@@ -614,7 +615,7 @@ namespace Nonatomic.ServiceKit
 					
 					sb.Append(serviceType.Name);
 					
-					if (!attr.Required && locator?.IsServiceRegistered(serviceType) == true)
+					if (!attr.Required && _serviceKitLocator.IsServiceRegistered(serviceType))
 					{
 						sb.Append(" (optional but registered)");
 					}
@@ -625,11 +626,11 @@ namespace Nonatomic.ServiceKit
 				sb.Append(".");
 		}
 
-		private bool IsServiceMissing(Type serviceType, bool isRequired, ServiceKitLocator locator)
+		private bool IsServiceMissing(Type serviceType, bool isRequired)
 		{
 			var service = _serviceKitLocator.GetService(serviceType);
-			var isRegistered = locator?.IsServiceRegistered(serviceType) ?? false;
-			
+			var isRegistered = _serviceKitLocator.IsServiceRegistered(serviceType);
+
 			// Service is missing if it's null and either required or registered (but not ready)
 			return service == null && (isRequired || isRegistered);
 		}

--- a/Runtime/ServiceKitBehaviour.cs
+++ b/Runtime/ServiceKitBehaviour.cs
@@ -33,7 +33,16 @@ namespace Nonatomic.ServiceKit
 		/// <summary>
 		/// Returns the active service locator. Uses the override if set, otherwise falls back to the serialized field.
 		/// </summary>
-		protected IServiceKitLocator Locator => _locatorOverride ?? ServiceKitLocator;
+		protected IServiceKitLocator Locator => ResolveLocator();
+
+		/// <summary>
+		/// Resolves the active service locator. Override this to supply a locator from a custom source
+		/// (e.g. a global registry, a parent component, or an addressable) instead of the serialized
+		/// field - the serialized field cannot be typed as the interface, so this is the extension
+		/// point for alternative <see cref="IServiceKitLocator"/> implementations. Defaults to the
+		/// UseLocator() override if set, otherwise the serialized ServiceKitLocator field.
+		/// </summary>
+		protected virtual IServiceKitLocator ResolveLocator() => _locatorOverride ?? ServiceKitLocator;
 
 		/// <summary>
 		/// Sets an override for the ServiceKitLocator. Useful for unit testing with mocks.

--- a/Runtime/ServiceKitLocator.cs
+++ b/Runtime/ServiceKitLocator.cs
@@ -520,12 +520,12 @@ namespace Nonatomic.ServiceKit
 		[System.Obsolete("Use Inject(target) or the InjectAsync(target, token) extension method instead.")]
 		public IServiceInjectionBuilder InjectServicesAsync(object target)
 		{
-			return new ServiceInjectionBuilder(this, target);
+			return new ServiceInjectionBuilder(this, target, _dependencyGraph);
 		}
 
 		public IServiceInjectionBuilder Inject(object target)
 		{
-			return new ServiceInjectionBuilder(this, target);
+			return new ServiceInjectionBuilder(this, target, _dependencyGraph);
 		}
 
 		public void UnregisterService<T>() where T : class


### PR DESCRIPTION
Acts on the "extensibility theatre" finding from the package review: `IServiceKitLocator` looked like an extension seam, but the injection engine was hard-bound to the concrete `ServiceKitLocator`.

## What changed
- **`IServiceKitLocator`** gains `TryResolveService(Type, out object)` and `HasCircularDependencyError(<T>/Type)` — both were public on the concrete class and documented as V2 features, but missing from the interface. (`ServiceResolutionStatus` was already public.)
- **`ServiceInjectionBuilder`** no longer downcasts `IServiceKitLocator` → `ServiceKitLocator` in its logic. The three `as ServiceKitLocator` casts are gone from `ResolveOptionalService` and `AppendWaitingServices`/`IsServiceMissing`; the only remaining cast is a public-ctor *fallback*. The concrete locator now passes its dependency graph in through a new `internal` ctor instead of having it re-discovered by downcast.
- **The silent bug**: `ResolveOptionalService` started with `if (locator == null) return (field, null, ...)`, so optional-dependency injection no-opped **every field** against any non-concrete `IServiceKitLocator`. Removed.
- **`ServiceKitBehaviour.ResolveLocator()`** — new `protected virtual` hook. The serialized `ServiceKitLocator` field can't be typed as the interface, so this is the override point for supplying an alternative locator (global registry, parent component, addressable, etc.).

## Validation (Unity 6000.3.16f1, batchmode)
- **EditMode 113/113, PlayMode 16/16.** The key regression risk — removing the casts breaking the concrete locator's optional-dependency path — is covered by the existing `OptionalDependency*` tests, which pass.

## Breaking-change note
`IServiceKitLocator` gained members. Anyone who implemented the interface themselves (rare) must add them. Suggest a **2.4.0** release. A CHANGELOG `[Unreleased]` entry covering this plus the merged perf/packaging work (#18) is included.