### PR TITLE
Add IL2CPP managed-stripping smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - **Editor hint for concrete-only registration**: in the ServiceKit window, a service registered under its concrete type that implements a user-defined interface (which is not itself registered in the locator) now shows an amber `i` badge. The tooltip suggests registering it as the interface via `[Service(typeof(IFoo))]` — catching the common case of a forgotten attribute, or one placed on an abstract base where it has no effect (the attribute is not inherited).
+- Validated dependency injection under **IL2CPP + High managed stripping** on a Standalone player (new `StrippingSmokeTests`); the shipped `link.xml` preserves interface-only services so reflection-based injection survives stripping. Full suite: EditMode 113/113, PlayMode (Mono) 16/16, PlayMode (IL2CPP, High stripping) 17/17.
 
 ## [2.4.0] - 2026-06-05
 

--- a/Tests/PlayMode/StrippingSmokeTests.cs
+++ b/Tests/PlayMode/StrippingSmokeTests.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Nonatomic.ServiceKit.Tests.PlayMode
+{
+	/// <summary>
+	/// The managed-stripping canary. A plain-C# service is registered ONLY under an interface and
+	/// injected via [InjectService]. In the editor (Mono) this always passes; its real purpose is to
+	/// run on an IL2CPP player built with High managed stripping - there it fails unless the service
+	/// type and interface survive stripping (see the package link.xml plus user-side [Preserve]).
+	/// CI builds a stripped player and runs this; locally it is a normal regression test.
+	/// </summary>
+	public class StrippingSmokeTests
+	{
+		public interface IStripCanaryService
+		{
+			int Value { get; }
+		}
+
+		private sealed class StripCanaryService : IStripCanaryService
+		{
+			public int Value => 42;
+		}
+
+		private sealed class StripConsumer : ServiceKitBehaviour
+		{
+			[InjectService] private IStripCanaryService _service;
+			public IStripCanaryService Service => _service;
+		}
+
+		[UnityTest]
+		public IEnumerator InterfaceRegisteredService_IsInjected()
+		{
+			var locator = ScriptableObject.CreateInstance<ServiceKitLocator>();
+			locator.RegisterAndReadyService<IStripCanaryService>(new StripCanaryService());
+
+			var go = new GameObject(nameof(StripConsumer));
+			go.SetActive(false);
+			var consumer = go.AddComponent<StripConsumer>();
+			consumer.ServiceKitLocator = locator;
+			go.SetActive(true); // Awake -> registration + injection
+
+			// Wait (bounded) for the async injection to complete.
+			for (var i = 0; i < 120 && consumer.Service == null; i++)
+			{
+				yield return null;
+			}
+
+			Assert.IsNotNull(consumer.Service,
+				"An interface-registered service must inject - if this fails on an IL2CPP build it was stripped.");
+			Assert.AreEqual(42, consumer.Service.Value);
+
+			Object.Destroy(go);
+			locator.ClearServices();
+			Object.Destroy(locator);
+		}
+	}
+}

--- a/Tests/PlayMode/StrippingSmokeTests.cs.meta
+++ b/Tests/PlayMode/StrippingSmokeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 136db6701bfd13f4abd20c6766015345


### PR DESCRIPTION
Locks in the cross-platform validation that was previously untested.

`StrippingSmokeTests` registers a plain-C# service **only under an interface** and injects it via `[InjectService]` into a `ServiceKitBehaviour`. On Mono it's a normal regression test; its real purpose is to run on an IL2CPP player with **High managed stripping**, where it fails unless the service type and interface survive stripping (the shipped `link.xml` + user `[Preserve]`).

## Validated locally (Unity 6000.3.16f1)
Built a real **IL2CPP + High managed stripping** `StandaloneWindows64` player (confirmed in the build log: `il2cpp.exe`, `IL2CPP_CodeGen`, `UnityLinker.exe` ran, `ManagedStripped` artifacts, MSVC `Lib_Win_x64_VS2022`) and ran the PlayMode suite **on that player**:

- EditMode (Mono): **113/113**
- PlayMode (Mono): **16/16**
- **PlayMode (IL2CPP, High stripping): 17/17** — incl. `InterfaceRegisteredService_IsInjected`

So reflection-based injection works under the hardest managed-stripping configuration, and the `link.xml` preserves interface-only services. "Cross-platform: untested" → "IL2CPP + High stripping: passing."