### PR TITLE
Fix UniTask compile regression; require UniTask on WebGL (2.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2.5.1] - 2026-06-07
+
+### Fixed
+- **UniTask compile regression**: 2.4.0 dropped the UniTask assembly reference from the runtime asmdef (and the Unit Testing sample), so ServiceKit failed to compile in any project that has UniTask installed. Restored. The reference is by GUID, so it resolves when UniTask is present and is harmlessly ignored when it is not.
+- **WebGL requires UniTask**: WebGL has no thread pool, so the `System.Threading.Tasks` injection path cannot resume an awaiter waiting for a not-yet-ready service — the injection silently hangs (only already-ready dependencies resolve). UniTask's player-loop async resumes correctly, so a WebGL target now requires it. ServiceKit logs a startup warning in a WebGL build without UniTask, and the README documents the requirement. Validated on an IL2CPP WebGL player.
+- **Edit-mode injection hang under UniTask**: the one-frame "wait for the Awake phase" defer used `UniTask.NextFrame()`, which never resumes without a running player loop (e.g. edit-mode tooling, or `async Task` tests), hanging injection of optional or not-yet-registered dependencies. Edit mode has no Awake phase to wait for, so the defer is skipped there. Run-state is read from a thread-safe snapshot because the continuation can resume off the main thread.
+
+### Added
+- Single-threaded async-resume PlayMode tests (a required dependency that becomes ready mid-wait, and an absent optional dependency) that exercise the injection resume path without the thread pool, regression-guarding the WebGL/UniTask behaviour. Both builds run green: non-UniTask EditMode 113 / PlayMode 19, UniTask EditMode 111 (the two `System.Threading.Tasks`-internals fixtures excluded) / PlayMode 19.
+
 ## [2.5.0] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ public class GameSettings : ServiceKitBehaviour
 
 ServiceKit provides automatic optimization when [UniTask](https://github.com/Cysharp/UniTask) is installed in your project. UniTask is a high-performance, zero-allocation async library specifically designed for Unity.
 
+> ### ⚠️ WebGL requires UniTask
+>
+> On most platforms UniTask is an optional performance upgrade. **On WebGL it is required.** WebGL has no thread pool, so the default `System.Threading.Tasks` path cannot resume an awaiter that is waiting for a not-yet-ready service — the injection silently hangs (only injections whose dependencies are *already* ready complete). UniTask is player-loop based and resumes correctly, so any project targeting WebGL **must** install UniTask. ServiceKit logs a warning at startup in a WebGL build that does not have it. (Validated on an IL2CPP WebGL player: the await-then-resume path fails on `Task` and passes on UniTask.)
+
 ### Automatic Detection
 
 ServiceKit automatically detects when UniTask is available and seamlessly switches to use UniTask APIs for enhanced performance:

--- a/Runtime/ServiceInjectionBuilder.cs
+++ b/Runtime/ServiceInjectionBuilder.cs
@@ -430,6 +430,13 @@ namespace Nonatomic.ServiceKit
 #if SERVICEKIT_UNITASK
 		private async UniTask WaitForAwakePhaseCompletion()
 		{
+			// Edit mode has no Awake phase to wait for, and UniTask.NextFrame() never resumes without a
+			// running player loop (e.g. an async-Task EditMode test) - so the defer is both pointless and
+			// a hang there. Only defer in play mode / player builds, where Awake ordering is real.
+			// ServiceKitRuntimeState.IsPlaying (not Application.isPlaying) because this continuation can
+			// resume on a worker thread, where the Unity API would throw.
+			if (!ServiceKitRuntimeState.IsPlaying) return;
+
 			// Yield to allow other Awake calls to complete registration
 			await UniTask.NextFrame();
 		}

--- a/Runtime/ServiceKitRuntimeState.cs
+++ b/Runtime/ServiceKitRuntimeState.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Nonatomic.ServiceKit
+{
+	/// <summary>
+	/// Thread-safe snapshot of whether the player is running. <see cref="Application.isPlaying"/> may
+	/// only be read on the main thread, but async injection continuations can resume on a worker thread
+	/// (e.g. when a consumer awaits the injection with <c>ConfigureAwait(false)</c>). This caches the
+	/// state on the main thread via Unity lifecycle hooks so injection code can read it from anywhere
+	/// without throwing.
+	/// </summary>
+	internal static class ServiceKitRuntimeState
+	{
+		// volatile so writes from the main thread are visible to a reader on a worker thread.
+		private static volatile bool _isPlaying;
+
+		/// <summary>True in a player build and in editor play mode; false in editor edit mode.</summary>
+		public static bool IsPlaying => _isPlaying;
+
+		// Runs when the player loop starts (both in builds and on entering editor play mode), and before
+		// any scene loads. In edit mode it never runs, so the field stays false there.
+		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+		private static void OnRuntimeLoad() => _isPlaying = true;
+
+#if UNITY_EDITOR
+		// Keeps the flag correct across play-mode transitions in the interactive editor, where the static
+		// can survive a domain reload (or "Enter Play Mode Without Domain Reload"). Without this it would
+		// stay true after exiting play, so a later edit-mode injection would wrongly try to defer.
+		[InitializeOnLoadMethod]
+		private static void HookEditor()
+		{
+			_isPlaying = EditorApplication.isPlayingOrWillChangePlaymode;
+			EditorApplication.playModeStateChanged += change =>
+			{
+				switch (change)
+				{
+					case PlayModeStateChange.EnteredPlayMode:
+						_isPlaying = true;
+						break;
+					case PlayModeStateChange.ExitingPlayMode:
+					case PlayModeStateChange.EnteredEditMode:
+						_isPlaying = false;
+						break;
+				}
+			};
+		}
+#endif
+	}
+}

--- a/Runtime/ServiceKitRuntimeState.cs.meta
+++ b/Runtime/ServiceKitRuntimeState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7b64b9dcd19b5b54f9ab9eb76fcdb04c

--- a/Runtime/ServiceKitWebGLGuard.cs
+++ b/Runtime/ServiceKitWebGLGuard.cs
@@ -1,0 +1,24 @@
+#if UNITY_WEBGL && !UNITY_EDITOR && !SERVICEKIT_UNITASK
+using UnityEngine;
+
+namespace Nonatomic.ServiceKit
+{
+	/// <summary>
+	/// WebGL has no thread pool, so the System.Threading.Tasks injection path cannot resume an
+	/// awaiter that waits for a not-yet-ready service - injection silently hangs. UniTask is
+	/// player-loop-based and works. This warns at startup in WebGL player builds that do not have
+	/// UniTask, so the failure mode is explained instead of debugged cold. Compiled out everywhere else.
+	/// </summary>
+	internal static class ServiceKitWebGLGuard
+	{
+		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+		private static void WarnUniTaskRequired()
+		{
+			Debug.LogWarning(
+				"[ServiceKit] On WebGL, asynchronous injection that waits for a not-yet-ready service " +
+				"cannot complete on the System.Threading.Tasks path (no thread pool to resume continuations). " +
+				"Install UniTask (com.cysharp.unitask) so ServiceKit uses its player-loop async path (SERVICEKIT_UNITASK).");
+		}
+	}
+}
+#endif

--- a/Runtime/ServiceKitWebGLGuard.cs.meta
+++ b/Runtime/ServiceKitWebGLGuard.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d02e2853415382c428df7329890d3055

--- a/Runtime/com.nonatomic.servicekit.runtime.asmdef
+++ b/Runtime/com.nonatomic.servicekit.runtime.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "com.nonatomic.servicekit.runtime",
     "rootNamespace": "Nonatomic.ServiceKit",
-    "references": [],
+    "references": [
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/Samples~/10 - Unit Testing/ServiceKitSamples.UnitTesting.asmdef
+++ b/Samples~/10 - Unit Testing/ServiceKitSamples.UnitTesting.asmdef
@@ -2,7 +2,8 @@
     "name": "ServiceKitSamples.UnitTesting",
     "rootNamespace": "ServiceKitSamples.UnitTestingExample",
     "references": [
-        "GUID:1b0144b25b4099e45a5beb8f8f7bee63"
+        "GUID:1b0144b25b4099e45a5beb8f8f7bee63",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Samples~/10 - Unit Testing/Tests.meta
+++ b/Samples~/10 - Unit Testing/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ae908ab4dc854a4cb323487df141024
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/10 - Unit Testing/Tests/GameControllerTests.cs
+++ b/Samples~/10 - Unit Testing/Tests/GameControllerTests.cs
@@ -3,13 +3,14 @@ using NUnit.Framework;
 using Nonatomic.ServiceKit;
 using UnityEngine;
 
+using System.Threading.Tasks;
 #if SERVICEKIT_UNITASK
 using Cysharp.Threading.Tasks;
-using TestTask = Cysharp.Threading.Tasks.UniTask;
-#else
-using System.Threading.Tasks;
-using TestTask = System.Threading.Tasks.Task;
 #endif
+
+// Test methods always return System.Threading.Tasks.Task so the NUnit runner can await them; the
+// runner cannot await a UniTask-returning method. TestAwake() may return a UniTask under
+// SERVICEKIT_UNITASK, but a UniTask is awaitable from inside an async Task, so the bodies are unchanged.
 
 namespace ServiceKitSamples.UnitTestingExample.Tests
 {
@@ -81,7 +82,7 @@ namespace ServiceKitSamples.UnitTestingExample.Tests
 		}
 
 		[Test]
-		public async TestTask TestAwake_InjectsBothDependencies()
+		public async Task TestAwake_InjectsBothDependencies()
 		{
 			await _controller.TestAwake(CancellationToken.None);
 
@@ -90,7 +91,7 @@ namespace ServiceKitSamples.UnitTestingExample.Tests
 		}
 
 		[Test]
-		public async TestTask CollectItem_AccumulatesScore()
+		public async Task CollectItem_AccumulatesScore()
 		{
 			await _controller.TestAwake(CancellationToken.None);
 
@@ -101,7 +102,7 @@ namespace ServiceKitSamples.UnitTestingExample.Tests
 		}
 
 		[Test]
-		public async TestTask StartNewGame_ResetsScore()
+		public async Task StartNewGame_ResetsScore()
 		{
 			await _controller.TestAwake(CancellationToken.None);
 			_controller.CollectItem(50);
@@ -113,7 +114,7 @@ namespace ServiceKitSamples.UnitTestingExample.Tests
 		}
 
 		[Test]
-		public async TestTask EndGame_SubmitsCurrentScoreToLeaderboard()
+		public async Task EndGame_SubmitsCurrentScoreToLeaderboard()
 		{
 			await _controller.TestAwake(CancellationToken.None);
 			_controller.CollectItem(120);

--- a/Tests/EditMode/AwaiterCancellationTests.cs
+++ b/Tests/EditMode/AwaiterCancellationTests.cs
@@ -4,6 +4,10 @@ using NUnit.Framework;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
+// This fixture asserts System.Threading.Tasks awaiter internals (ContinueWith / IsCompleted and the
+// RunContinuationsAsynchronously lock-safety). UniTask has a different continuation model, so the
+// fixture only applies to the non-UniTask build.
+#if !SERVICEKIT_UNITASK
 namespace Tests.EditMode
 {
 	/// <summary>
@@ -80,3 +84,4 @@ namespace Tests.EditMode
 		}
 	}
 }
+#endif

--- a/Tests/PlayMode/AsyncResumeTests.cs
+++ b/Tests/PlayMode/AsyncResumeTests.cs
@@ -1,0 +1,97 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Nonatomic.ServiceKit.Tests.PlayMode
+{
+	/// <summary>
+	/// Definitive single-threaded async-resumption tests. These exist to validate WebGL (no thread
+	/// pool): does an injection that genuinely *awaits* a not-yet-ready service resume and complete
+	/// when continuations can only run on the main-thread frame pump? The pre-existing tests all used
+	/// the ready-immediately fast path (or thread-pool scaffolding), so this gap was untested.
+	/// Waits are deliberately generous because, single-threaded, each await hop costs a frame pump.
+	/// </summary>
+	public class AsyncResumeTests
+	{
+		public interface IRequiredDep { int Value { get; } }
+		private sealed class RequiredDep : IRequiredDep { public int Value => 7; }
+
+		public interface IOptionalDep { }
+
+#pragma warning disable 0169
+		private sealed class RequiredConsumer : ServiceKitBehaviour
+		{
+			[InjectService] private IRequiredDep _dep;
+			public IRequiredDep Dep => _dep;
+			public bool Initialized { get; private set; }
+			protected override void InitializeService() => Initialized = true;
+		}
+
+		private sealed class OptionalConsumer : ServiceKitBehaviour
+		{
+			[InjectService(Required = false)] private IOptionalDep _opt;
+			public IOptionalDep Opt => _opt;
+			public bool Initialized { get; private set; }
+			protected override void InitializeService() => Initialized = true;
+		}
+#pragma warning restore 0169
+
+		private static T AddConsumer<T>(ServiceKitLocator locator, out GameObject go) where T : ServiceKitBehaviour
+		{
+			go = new GameObject(typeof(T).Name);
+			go.SetActive(false);
+			var consumer = go.AddComponent<T>();
+			consumer.ServiceKitLocator = locator;
+			go.SetActive(true); // Awake -> registration + injection
+			return consumer;
+		}
+
+		// A required dependency is registered-not-ready; the consumer must AWAIT it, then resume and
+		// complete once it becomes ready. This is the path that only works if continuations resume on
+		// the frame pump without a thread pool. Fails (or hangs -> bounded here) if WebGL can't resume.
+		[UnityTest]
+		public IEnumerator RequiredDep_BecomesReadyDuringWait_ResumesAndInjects()
+		{
+			var locator = ScriptableObject.CreateInstance<ServiceKitLocator>();
+			locator.RegisterService<IRequiredDep>(new RequiredDep()); // registered, NOT ready
+			var consumer = AddConsumer<RequiredConsumer>(locator, out var go);
+
+			// Let the consumer reach the await (still null = still waiting).
+			for (var i = 0; i < 60 && consumer.Dep == null; i++) yield return null;
+			Assert.IsNull(consumer.Dep, "Consumer should still be awaiting the not-ready dependency");
+
+			locator.ReadyService<IRequiredDep>();
+
+			// Generous: single-threaded resume + the rest of the injection chain, one hop per frame.
+			for (var i = 0; i < 600 && !consumer.Initialized; i++) yield return null;
+
+			Assert.IsNotNull(consumer.Dep, "Required dependency must inject after it becomes ready");
+			Assert.AreEqual(7, consumer.Dep.Value);
+			Assert.IsTrue(consumer.Initialized, "Injection must complete (InitializeService must run)");
+
+			Object.Destroy(go);
+			locator.ClearServices();
+			Object.Destroy(locator);
+		}
+
+		// An optional dependency is never registered. Injection must still COMPLETE (skip it). This
+		// exercises WaitForAwakePhaseCompletion (the non-UniTask Task.Delay(1) yield) - if that does
+		// not resume on WebGL, injection never finishes and Initialized stays false.
+		[UnityTest]
+		public IEnumerator OptionalDep_NotRegistered_InjectionStillCompletes()
+		{
+			var locator = ScriptableObject.CreateInstance<ServiceKitLocator>();
+			var consumer = AddConsumer<OptionalConsumer>(locator, out var go);
+
+			for (var i = 0; i < 600 && !consumer.Initialized; i++) yield return null;
+
+			Assert.IsTrue(consumer.Initialized, "Injection must complete even when an optional dependency is absent");
+			Assert.IsNull(consumer.Opt, "Unregistered optional dependency should be left null");
+
+			Object.Destroy(go);
+			locator.ClearServices();
+			Object.Destroy(locator);
+		}
+	}
+}

--- a/Tests/PlayMode/AsyncResumeTests.cs.meta
+++ b/Tests/PlayMode/AsyncResumeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed308836ab970d548b8e21c8e7cd1f87

--- a/Tests/PlayMode/InjectionFailureReportingTests.cs
+++ b/Tests/PlayMode/InjectionFailureReportingTests.cs
@@ -85,15 +85,17 @@ namespace Nonatomic.ServiceKit.Tests.PlayMode
 
 			var go = AddConsumer<RequiresPendingBehaviour>(_locator);
 
-			// Let the consumer reach the waiting state.
-			for (var i = 0; i < 3; i++) yield return null;
+			// Let the consumer reach the waiting state. Generous because, single-threaded (WebGL), each
+			// async hop to the await costs a frame pump.
+			for (var i = 0; i < 60; i++) yield return null;
 
 			// Unregistering the awaited service while the target is alive is a warning, not an error.
 			LogAssert.Expect(LogType.Warning, new Regex("Failed to inject required services"));
 
 			_locator.UnregisterService(typeof(IPendingService));
 
-			for (var i = 0; i < 5; i++) yield return null;
+			// The fault propagates back up the await chain one frame-pump at a time; wait generously.
+			for (var i = 0; i < 120; i++) yield return null;
 
 			Object.Destroy(go);
 			yield return null;

--- a/Tests/PlayMode/SceneCleanupPlayerTests.cs
+++ b/Tests/PlayMode/SceneCleanupPlayerTests.cs
@@ -1,0 +1,83 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Nonatomic.ServiceKit.Tests.PlayMode
+{
+	/// <summary>
+	/// Validates scene cleanup in an actual player build. When run on a standalone player
+	/// UNITY_EDITOR is undefined, so ServiceInfo.DebugData is compiled out and cleanup must
+	/// rely on the runtime SceneHandle / IsDontDestroyOnLoad metadata. These tests would have
+	/// behaved differently before the runtime-scene-metadata fix.
+	/// </summary>
+	public class SceneCleanupPlayerTests
+	{
+		public interface IPlainService { }
+		public class PlainService : IPlainService { }
+
+		public interface ISceneService { }
+		public class SceneMonoService : MonoBehaviour, ISceneService { }
+
+		private ServiceKitLocator _locator;
+
+		[SetUp]
+		public void Setup()
+		{
+			_locator = ScriptableObject.CreateInstance<ServiceKitLocator>();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (_locator == null) return;
+			_locator.ClearServices();
+			Object.Destroy(_locator);
+			_locator = null;
+		}
+
+		[Test]
+		public void RuntimeSceneHandle_IsPopulated_InPlayer()
+		{
+			var go = new GameObject("SceneSvc");
+			try
+			{
+				var mb = go.AddComponent<SceneMonoService>();
+				_locator.RegisterAndReadyService<ISceneService>(mb);
+
+				var info = _locator.GetAllServices().First(s => s.ServiceType == typeof(ISceneService));
+				Assert.IsTrue(info.SceneHandle == go.scene.handle && info.SceneHandle != -1,
+					$"Runtime scene handle must be populated in a player build (got {info.SceneHandle})");
+			}
+			finally
+			{
+				Object.Destroy(go);
+			}
+		}
+
+		[Test]
+		public void UnregisterServicesFromScene_RemovesSceneServices_InPlayer()
+		{
+			_locator.RegisterAndReadyService<IPlainService>(new PlainService());
+
+			var go = new GameObject("SceneSvc");
+			try
+			{
+				var mb = go.AddComponent<SceneMonoService>();
+				_locator.RegisterAndReadyService<ISceneService>(mb);
+
+				Assert.IsTrue(_locator.IsServiceRegistered<ISceneService>());
+
+				_locator.UnregisterServicesFromScene(go.scene);
+
+				Assert.IsFalse(_locator.IsServiceRegistered<ISceneService>(),
+					"MonoBehaviour service in the unloaded scene should be removed in a player build");
+				Assert.IsTrue(_locator.IsServiceRegistered<IPlainService>(),
+					"Non-scene service should survive scene unload in a player build");
+			}
+			finally
+			{
+				Object.Destroy(go);
+			}
+		}
+	}
+}

--- a/Tests/PlayMode/SceneCleanupPlayerTests.cs.meta
+++ b/Tests/PlayMode/SceneCleanupPlayerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ceacf44eea11864a9e845684203d7d7

--- a/Tests/PlayMode/ServiceKitRuntimeExitTests.cs
+++ b/Tests/PlayMode/ServiceKitRuntimeExitTests.cs
@@ -220,25 +220,13 @@ namespace Nonatomic.ServiceKit.Tests.PlayMode
 			// Arrange
 			var awaitTasks = new List<Task>();
 			
-			// Create multiple services that will be awaited
+			// Create multiple awaiters ON THE MAIN THREAD. Task.Run schedules on the thread pool,
+			// which does not exist on WebGL - there the lambda never runs and the tasks never complete.
 			for (int i = 0; i < 5; i++)
 			{
-				var serviceType = typeof(ITestService);
-				var task = Task.Run(async () =>
-				{
-					try
-					{
-						var cts = new CancellationTokenSource();
-						_cancellationTokens.Add(cts);
-						
-						await _locator.GetServiceAsync(serviceType, cts.Token);
-					}
-					catch (OperationCanceledException)
-					{
-						// Expected during cleanup - TaskCanceledException derives from this
-					}
-				});
-				awaitTasks.Add(task);
+				var cts = new CancellationTokenSource();
+				_cancellationTokens.Add(cts);
+				awaitTasks.Add(AwaitServiceSwallowingCancellation(typeof(ITestService), cts.Token));
 			}
 
 			// Wait a moment for awaiters to be registered
@@ -248,15 +236,28 @@ namespace Nonatomic.ServiceKit.Tests.PlayMode
 			_locator.ClearServices();
 			ServiceKitTimeoutManager.Cleanup();
 
-			// Wait for all tasks to complete
-			yield return new WaitUntil(() => 
-				awaitTasks.TrueForAll(t => t.IsCompleted) || Time.time > 5f);
+			// Wait (relative) for all tasks to complete - continuations pump on the main-thread frames.
+			var start = Time.time;
+			yield return new WaitUntil(() =>
+				awaitTasks.TrueForAll(t => t.IsCompleted) || Time.time - start > 5f);
 
 			// Assert - All tasks should be completed (cancelled)
 			foreach (var task in awaitTasks)
 			{
 				Assert.IsTrue(task.IsCompleted, "All await tasks should be completed");
 				Assert.IsFalse(task.IsFaulted, "Tasks should not be faulted");
+			}
+		}
+
+		private async System.Threading.Tasks.Task AwaitServiceSwallowingCancellation(System.Type serviceType, CancellationToken cancellationToken)
+		{
+			try
+			{
+				await _locator.GetServiceAsync(serviceType, cancellationToken);
+			}
+			catch (OperationCanceledException)
+			{
+				// Expected during cleanup.
 			}
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.nonatomic.servicekit",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "displayName": "Service Kit",
   "description": "A lightweight dependency injection and service locator framework for Unity. Attribute-based registration, async resolution, fluent API, optional dependencies, service tags, scene-aware lifecycle, and UniTask support.",
   "unity": "2022.3",


### PR DESCRIPTION
## 2.5.1 — UniTask regression fix + WebGL requirement

### Fixed
- **UniTask compile regression.** 2.4.0 dropped the UniTask assembly reference from the runtime asmdef (and the Unit Testing sample), so ServiceKit failed to compile in any project with UniTask installed. Restored. The reference is by GUID — it resolves when UniTask is present and is harmlessly ignored when it is not.
- **WebGL requires UniTask.** WebGL has no thread pool, so the `System.Threading.Tasks` injection path cannot resume an awaiter waiting for a not-yet-ready service — the injection silently hangs (only already-ready dependencies resolve). UniTask's player-loop async resumes correctly. A startup warning now fires in a WebGL build without UniTask, and the README documents the requirement. Verified empirically on an IL2CPP WebGL player: the await→resume path fails on `Task` and passes on UniTask.
- **Edit-mode injection hang under UniTask.** The one-frame "wait for the Awake phase" defer used `UniTask.NextFrame()`, which never resumes without a running player loop (edit-mode tooling, `async Task` tests), hanging injection of optional or not-yet-registered dependencies. Edit mode has no Awake phase to wait for, so the defer is skipped there. Run-state is read from a thread-safe snapshot (`ServiceKitRuntimeState`) because the continuation can resume off the main thread — `Application.isPlaying` is main-thread-only.

### Added
- `AsyncResumeTests` — single-threaded async-resume PlayMode tests (required dep becomes ready mid-wait; absent optional dep) that exercise the resume path without the thread pool, regression-guarding the WebGL/UniTask behaviour.

### Validation
Full suites, both configurations, on Unity 6000.3.16f1:

| Config | EditMode | PlayMode |
| --- | --- | --- |
| Default (no UniTask) | 113 / 113 | 19 / 19 |
| UniTask 2.5.10 | 111 / 111¹ | 19 / 19 |

¹ The two `System.Threading.Tasks`-internals fixtures (`AwaiterCancellationTests`) are correctly excluded under UniTask.
