### PR TITLE
Injection perf + locator interface facets + off-thread fix (2.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2.6.0] - 2026-06-07
+
+### Added
+- The locator interface is now composed from focused facets — `IServiceLocator` (core register / ready / resolve / inject), `IServiceTagRegistry`, `IServiceSceneManager`, and `IServiceDiagnostics`. `IServiceKitLocator` inherits all four, so existing code and implementers are unaffected; new code and alternative locator implementations can depend on just the slice they need.
+
+### Changed
+- **Faster steady-state injection.** When every dependency of an object is already ready, injection now resolves and assigns synchronously — skipping the per-field async state machines, the task array + `WhenAll`, and the thread hop. Additionally, a type's dependency-graph edges are built once instead of on every injection, and the required-services and circular-dependency checks no longer allocate on the success path. Meaningfully less per-spawn GC when instantiating injected prefabs at runtime. Behaviour is unchanged: the fast path only triggers when all dependencies are already ready and the injection is on the Unity thread; anything else takes the existing async path.
+
+### Fixed
+- Injection-failure handling no longer risks a Unity main-thread exception when an injection was started off the main thread (or resumed there via `ConfigureAwait(false)`). The failure path now re-syncs to the Unity thread before any Unity-API access and reads play-state from a thread-safe snapshot. The non-UniTask edit-mode defer was also aligned with the UniTask path.
+- **README accuracy.** Corrected the UniTask install instructions to the official Cysharp source (`...UniTask#2.5.10`) and removed a corrupted link artifact; documented the typed injection exceptions and the 30-second default timeout; corrected the `IServiceInjectionBuilder` API reference (`Execute()` is not an interface member; added the missing members); and fixed the optional-dependency example to show the injection trigger.
+
 ## [2.5.1] - 2026-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -303,7 +303,8 @@ await serviceKit.GetServiceAsync<IPlayerService>();
 // With UniTask installed:   → Zero allocations, faster execution
 // Without UniTask:          → Standard Task performance
 ```
-## Installation
+
+### Installing UniTask
 
 Add **UniTask** to your Unity project via Package Manager:
 
@@ -311,10 +312,10 @@ Add **UniTask** to your Unity project via Package Manager:
 2. Click **+** > **Add package from git URL**
 3. Enter:
 ```
-https://www.pkglnk.dev/unitask.git?path=src/UniTask/Assets/Plugins/UniTask
-```[sw.js](../../../../beer-tilt/sw.js)
+https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2.5.10
+```
 
-[![pkglnk](https://www.pkglnk.dev/card/unitask.svg?variant=directory)](https://www.pkglnk.dev/pkg/unitask)
+> ServiceKit's `SERVICEKIT_UNITASK` define activates at UniTask **2.5.10 or newer**. The `#2.5.10` suffix pins that minimum; omit it to track the latest.
 
 ### Performance Benefits
 
@@ -462,6 +463,10 @@ public class PlayerController : ServiceKitBehaviour, IPlayerController
     {
         Debug.LogError($"Failed to initialize player controller: {exception.Message}");
 
+        // The exception is typed: a timeout arrives as ServiceInjectionTimeoutException (a
+        // TimeoutException) and an unregistered service as ServiceUnregisteredException (an
+        // OperationCanceledException). Both subclass their base type, so the checks below keep
+        // working; both also carry a .Kind discriminator if you need to branch precisely.
         if (exception is TimeoutException)
         {
             Debug.Log("Services took too long to become available");
@@ -577,13 +582,20 @@ Services can be marked as optional using intelligent 3-state dependency resoluti
 ```csharp
 public class AnalyticsReporter : MonoBehaviour
 {
+    [SerializeField] private ServiceKitLocator _serviceKit;
+
     [InjectService(Required = false)]
-    private IAnalyticsService _analyticsService; // Uses intelligent resolution
+    private IAnalyticsService _analyticsService; // Optional - stays null if never registered
 
     [InjectService]
-    private IPlayerService _playerService; // Required - will fail if missing
+    private IPlayerService _playerService; // Required - injection fails if missing
 
-    // ...
+    private async void Awake()
+    {
+        // Injection is what populates the fields; a plain MonoBehaviour must trigger it itself
+        // (a ServiceKitBehaviour does this for you). After this, _analyticsService may be null.
+        await _serviceKit.InjectAsync(this, destroyCancellationToken);
+    }
 }
 ```
 
@@ -779,6 +791,11 @@ IReadOnlyList<ServiceInfo> GetServicesWithAllTags(params string[] tags);
 
 // Management
 IReadOnlyList<ServiceInfo> GetAllServices();
+
+// Curated subset. The interface also exposes status checks (IsServiceRegistered<T>,
+// IsServiceReady<T>, GetServiceStatus<T>), tag mutators (AddTagsToService, RemoveTagsFromService,
+// GetServiceTags), and scene tooling (GetServicesInScene, UnregisterServicesFromScene,
+// CleanupDestroyedServices). See IServiceKitLocator.cs for the full surface.
 ```
 
 ### IServiceRegistrationBuilder Interface
@@ -797,10 +814,15 @@ void Ready();     // Complete registration and mark as ready
 
 ```csharp
 IServiceInjectionBuilder WithCancellation(CancellationToken cancellationToken);
+IServiceInjectionBuilder WithTimeout();                        // Use the default timeout (30s, from ServiceKit Settings)
 IServiceInjectionBuilder WithTimeout(float timeoutSeconds);
+IServiceInjectionBuilder WithErrorHandling();                  // Use the default handler (logs against the target)
 IServiceInjectionBuilder WithErrorHandling(Action<Exception> errorHandler);
-void Execute(); // Fire-and-forget
-Task ExecuteAsync(); // Awaitable (UniTask when available)
+Task ExecuteAsync();                                           // Awaitable (UniTask when available)
+Task ExecuteWithCancellationAsync(CancellationToken token);    // Awaitable, applies the cancellation token
+
+// Fire-and-forget Execute() / ExecuteWithCancellation() also exist on the concrete
+// ServiceInjectionBuilder for advanced use; prefer the awaitable ExecuteAsync above.
 ```
 
 ## Best Practices

--- a/Runtime/IServiceKitLocator.cs
+++ b/Runtime/IServiceKitLocator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -12,7 +12,12 @@ using System.Threading.Tasks;
 
 namespace Nonatomic.ServiceKit
 {
-	public interface IServiceKitLocator
+	/// <summary>
+	/// Core service-locator surface: registration, readiness, retrieval (sync and async), injection and
+	/// resolution status. This is the slice the injection engine and most consumers actually depend on;
+	/// an alternative locator that only needs dependency injection can implement just this facet.
+	/// </summary>
+	public interface IServiceLocator
 	{
 		// Phase 1: Registration (service not available yet) - Generic
 		void RegisterService<T>(T service, [CallerMemberName] string registeredBy = null) where T : class;
@@ -25,30 +30,24 @@ namespace Nonatomic.ServiceKit
 		void RegisterService(Type serviceType, object service, ServiceTag[] tags, [CallerMemberName] string registeredBy = null);
 		void RegisterServiceWithCircularExemption(Type serviceType, object service, [CallerMemberName] string registeredBy = null);
 		void RegisterServiceWithCircularExemption(Type serviceType, object service, ServiceTag[] tags, [CallerMemberName] string registeredBy = null);
-		
+
 		// Phase 3: Ready (service becomes available)
 		void ReadyService<T>() where T : class;
 		void ReadyService(Type serviceType);
-		
+
 		// Convenience methods for simple services
 		void RegisterAndReadyService<T>(T service, [CallerMemberName] string registeredBy = null) where T : class;
 		void RegisterAndReadyService<T>(T service, ServiceTag[] tags, [CallerMemberName] string registeredBy = null) where T : class;
 		void RegisterAndReadyServiceWithCircularExemption<T>(T service, [CallerMemberName] string registeredBy = null) where T : class;
 		void RegisterAndReadyServiceWithCircularExemption<T>(T service, ServiceTag[] tags, [CallerMemberName] string registeredBy = null) where T : class;
-		
+
 		// Status checks
 		bool IsServiceRegistered<T>() where T : class;
 		bool IsServiceRegistered(Type serviceType);
 		bool IsServiceReady<T>() where T : class;
 		bool IsServiceReady(Type serviceType);
-		bool IsServiceCircularDependencyExempt<T>() where T : class;
-		bool IsServiceCircularDependencyExempt(Type serviceType);
-		bool HasCircularDependencyError<T>() where T : class;
-		bool HasCircularDependencyError(Type serviceType);
 		ServiceResolutionStatus TryResolveService(Type serviceType, out object service);
-		string GetServiceStatus<T>() where T : class;
-		string GetServiceStatus(Type serviceType);
-		
+
 		// Service retrieval (only returns ready services)
 		void UnregisterService<T>() where T : class;
 		void UnregisterService(Type serviceType);
@@ -63,19 +62,24 @@ namespace Nonatomic.ServiceKit
 		Task<T> GetServiceAsync<T>(CancellationToken cancellationToken = default) where T : class;
 		Task<object> GetServiceAsync(Type serviceType, CancellationToken cancellationToken = default);
 #endif
-		[System.Obsolete("Use Inject(target) or the InjectAsync(target, token) extension method instead.")]
+
+		// Injection
+		[Obsolete("Use Inject(target) or the InjectAsync(target, token) extension method instead.")]
 		IServiceInjectionBuilder InjectServicesAsync(object target);
 		IServiceInjectionBuilder Inject(object target);
 		void ClearServices();
 
-		// Tooling support
-		IReadOnlyList<ServiceInfo> GetAllServices();
-		IReadOnlyList<ServiceInfo> GetServicesInScene(string sceneName);
-		IReadOnlyList<ServiceInfo> GetDontDestroyOnLoadServices();
-		void UnregisterServicesFromScene(Scene scene);
-		void CleanupDestroyedServices();
-		
-		// Tag management
+		// Fluent registration API
+		IServiceRegistrationBuilder Register<T>(T service, [CallerMemberName] string registeredBy = null) where T : class;
+		IServiceRegistrationBuilder Register(object service, [CallerMemberName] string registeredBy = null);
+	}
+
+	/// <summary>
+	/// Tag assignment and tag-based queries. Optional facet - a locator that does not use service tags
+	/// need not provide these to satisfy the core <see cref="IServiceLocator"/>.
+	/// </summary>
+	public interface IServiceTagRegistry
+	{
 		void AddTagsToService<T>(params ServiceTag[] tags) where T : class;
 		void AddTagsToService(Type serviceType, params ServiceTag[] tags);
 		void RemoveTagsFromService<T>(params string[] tags) where T : class;
@@ -85,9 +89,41 @@ namespace Nonatomic.ServiceKit
 		IReadOnlyList<ServiceInfo> GetServicesWithTag(string tag);
 		IReadOnlyList<ServiceInfo> GetServicesWithAnyTag(params string[] tags);
 		IReadOnlyList<ServiceInfo> GetServicesWithAllTags(params string[] tags);
+	}
 
-		// Fluent registration API
-		IServiceRegistrationBuilder Register<T>(T service, [CallerMemberName] string registeredBy = null) where T : class;
-		IServiceRegistrationBuilder Register(object service, [CallerMemberName] string registeredBy = null);
+	/// <summary>
+	/// Scene-scoped lifecycle: enumerate services by scene and clean them up when scenes unload.
+	/// Optional facet, separate from the core locator so a non-scene-aware locator can skip it.
+	/// </summary>
+	public interface IServiceSceneManager
+	{
+		IReadOnlyList<ServiceInfo> GetServicesInScene(string sceneName);
+		IReadOnlyList<ServiceInfo> GetDontDestroyOnLoadServices();
+		void UnregisterServicesFromScene(Scene scene);
+		void CleanupDestroyedServices();
+	}
+
+	/// <summary>
+	/// Inspection and diagnostics: enumerate everything, report a service's status, and query
+	/// circular-dependency state. Optional facet used by tooling and the editor window.
+	/// </summary>
+	public interface IServiceDiagnostics
+	{
+		bool IsServiceCircularDependencyExempt<T>() where T : class;
+		bool IsServiceCircularDependencyExempt(Type serviceType);
+		bool HasCircularDependencyError<T>() where T : class;
+		bool HasCircularDependencyError(Type serviceType);
+		string GetServiceStatus<T>() where T : class;
+		string GetServiceStatus(Type serviceType);
+		IReadOnlyList<ServiceInfo> GetAllServices();
+	}
+
+	/// <summary>
+	/// The full ServiceKit locator surface, composed from the core locator plus the tag, scene and
+	/// diagnostics facets. Existing code keeps depending on this unchanged; new code (and alternative
+	/// locator implementations) can instead depend on only the facet(s) they need.
+	/// </summary>
+	public interface IServiceKitLocator : IServiceLocator, IServiceTagRegistry, IServiceSceneManager, IServiceDiagnostics
+	{
 	}
 }

--- a/Runtime/ServiceDependencyGraph.cs
+++ b/Runtime/ServiceDependencyGraph.cs
@@ -19,6 +19,9 @@ namespace Nonatomic.ServiceKit
 			public HashSet<Type> Dependencies { get; } = new HashSet<Type>();
 			public Dictionary<Type, string> DependencyFields { get; } = new Dictionary<Type, string>();
 			public bool IsResolving { get; set; }
+
+			// A type's [InjectService] fields are immutable, so its edges only need building once.
+			public bool DependenciesPopulated { get; set; }
 		}
 
 		internal sealed class CircularDependencyInfo
@@ -30,22 +33,29 @@ namespace Nonatomic.ServiceKit
 			public string FieldName { get; set; }
 		}
 
-		public void UpdateForTarget(Type serviceType, List<FieldInfo> fieldsToInject)
+		public void UpdateForTarget(Type serviceType, IReadOnlyList<FieldInfo> fieldsToInject)
 		{
 			lock (_graphLock)
 			{
 				var node = GetOrCreate(serviceType);
+				// Edges are derived from the type's immutable injectable fields, so building them once is
+				// enough. This skips the per-injection clear+rebuild churn under the lock when the same
+				// type is injected repeatedly (e.g. spawning many copies of a prefab).
+				if (node.DependenciesPopulated) return;
+
 				node.Dependencies.Clear();
 				node.DependencyFields.Clear();
-				foreach (var field in fieldsToInject)
+				for (var i = 0; i < fieldsToInject.Count; i++)
 				{
+					var field = fieldsToInject[i];
 					node.Dependencies.Add(field.FieldType);
 					node.DependencyFields[field.FieldType] = field.Name;
 				}
+				node.DependenciesPopulated = true;
 			}
 		}
 
-		public void UpdateForRegistration(Type serviceType, List<FieldInfo> fieldsToInject)
+		public void UpdateForRegistration(Type serviceType, IReadOnlyList<FieldInfo> fieldsToInject)
 		{
 			UpdateForTarget(serviceType, fieldsToInject);
 		}
@@ -54,15 +64,21 @@ namespace Nonatomic.ServiceKit
 		{
 			lock (_graphLock)
 			{
+				// Runs on every injection. Allocate nothing but the walk's path until a cycle is actually
+				// found - the CircularDependencyInfo and its path copy are pure garbage in the common case.
 				var path = new List<Type>();
-				var info = new CircularDependencyInfo();
-				if (!HasCircular(root, path, info))
+				if (!HasCircular(root, path, out var fromType, out var toType, out var fieldName))
 				{
 					return null;
 				}
-				info.TypesInPath = new List<Type>(path);
-				info.Path = string.Join(" → ", path.Select(t => t.Name));
-				return info;
+				return new CircularDependencyInfo
+				{
+					TypesInPath = new List<Type>(path),
+					Path = string.Join(" → ", path.Select(t => t.Name)),
+					FromType = fromType,
+					ToType = toType,
+					FieldName = fieldName,
+				};
 			}
 		}
 
@@ -215,8 +231,12 @@ namespace Nonatomic.ServiceKit
 			}
 		}
 
-		private bool HasCircular(Type serviceType, List<Type> path, CircularDependencyInfo info)
+		private bool HasCircular(Type serviceType, List<Type> path, out Type fromType, out Type toType, out string fieldName)
 		{
+			fromType = null;
+			toType = null;
+			fieldName = null;
+
 			if (_circularExempt.Contains(serviceType))
 			{
 				return false;
@@ -229,9 +249,9 @@ namespace Nonatomic.ServiceKit
 					_dependencyGraph.TryGetValue(path[lastIndex], out var lastNode) &&
 					lastNode.DependencyFields.TryGetValue(serviceType, out var completingField))
 				{
-					info.FromType = path[lastIndex];
-					info.ToType = serviceType;
-					info.FieldName = completingField;
+					fromType = path[lastIndex];
+					toType = serviceType;
+					fieldName = completingField;
 				}
 				return true;
 			}
@@ -244,7 +264,7 @@ namespace Nonatomic.ServiceKit
 					{
 						continue;
 					}
-					if (HasCircular(dep, path, info))
+					if (HasCircular(dep, path, out fromType, out toType, out fieldName))
 					{
 						return true;
 					}

--- a/Runtime/ServiceInjectionBuilder.cs
+++ b/Runtime/ServiceInjectionBuilder.cs
@@ -129,8 +129,29 @@ namespace Nonatomic.ServiceKit
 
 			try
 			{
+				// Capture the Unity context up front (and remember it globally): the fast path uses it to
+				// confirm it is on the Unity thread before assigning inline, and the async path marshals
+				// back to it. Falls back to the captured context when this injection was started off the
+				// main thread (Current is null there).
+				unityContext = SynchronizationContext.Current;
+				ServiceKitRuntimeState.CaptureUnityContext(unityContext);
+				unityContext ??= ServiceKitRuntimeState.UnityContext;
+
 				RegisterDependenciesForCircularDetection(fieldsToInject);
 				ThrowIfCircularDependencyDetected();
+
+				// Fast path: when every dependency is already ready AND we are on the Unity thread, resolve
+				// and assign synchronously - skipping the per-field state machines, the Task[]/WhenAll, and
+				// the thread hop. The dominant steady-state case (spawning an object whose services became
+				// ready long ago). It triggers only when ALL fields resolve to Ready, so it is semantically
+				// identical to the async path resolving them immediately; anything not-yet-ready falls
+				// through to the full async path below.
+				if (SynchronizationContext.Current == unityContext
+					&& TryResolveAllReadySynchronously(fieldsToInject, results))
+				{
+					AssignResolvedFields(results);
+					return;
+				}
 
 				if (_timeout > 0f)
 				{
@@ -149,7 +170,6 @@ namespace Nonatomic.ServiceKit
 					timeoutCts?.Token ?? CancellationToken.None))
 				{
 					var finalToken = linked.Token;
-					unityContext = SynchronizationContext.Current;
 
 					await ResolveAllServicesInParallel(fieldsToInject, finalToken, resolutionCts, timeoutCts, results);
 
@@ -161,6 +181,11 @@ namespace Nonatomic.ServiceKit
 			catch (OperationCanceledException oce)
 			{
 				var isExplicitTimeout = timeoutCts?.IsCancellationRequested ?? false;
+
+				// The awaited continuation may have resumed off the main thread; get back on it before any
+				// Unity-API access below (destroyed-target check in ClassifyCancellation, hierarchy/scene
+				// lookups in DescribeTarget). No-op when already on the Unity thread.
+				await ServiceKitThreading.SwitchToUnityThread(unityContext);
 
 				// Always try to inject any services that were successfully resolved before cancellation
 				await TryInjectResolvedServices(results, unityContext);
@@ -210,22 +235,52 @@ namespace Nonatomic.ServiceKit
 			return targetType;
 		}
 
-		private static List<FieldInfo> GetFieldsToInject(Type targetType)
+		private static IReadOnlyList<FieldInfo> GetFieldsToInject(Type targetType)
 		{
-			// Field discovery is cached per type (see ServiceKitReflectionCache); copy into a fresh
-			// list so the caller can treat it as owned.
-			return new List<FieldInfo>(ServiceKitReflectionCache.GetInjectableFields(targetType));
+			// Field discovery is cached per type (see ServiceKitReflectionCache). The cached array is
+			// immutable and never mutated by callers, so hand it back directly (read-only) instead of
+			// copying it into a fresh list on every injection.
+			return ServiceKitReflectionCache.GetInjectableFields(targetType);
 		}
 
-		private void RegisterDependenciesForCircularDetection(List<FieldInfo> fieldsToInject)
+		private void RegisterDependenciesForCircularDetection(IReadOnlyList<FieldInfo> fieldsToInject)
 		{
 			_dependencyGraph?.UpdateForTarget(_targetServiceType, fieldsToInject);
 			_dependencyGraph?.SetResolving(_targetServiceType, true);
 		}
 
+		// Synchronous resolution for the all-ready fast path. Returns true only if EVERY field's service
+		// is already Ready (populating results); returns false the moment one isn't, leaving that case to
+		// the async path. A RegisteredNotReady service or an absent optional deliberately fails this so the
+		// async path can wait / give late registrations a frame.
+		private bool TryResolveAllReadySynchronously(IReadOnlyList<FieldInfo> fieldsToInject, (FieldInfo field, object service, bool required)[] results)
+		{
+			for (var i = 0; i < fieldsToInject.Count; i++)
+			{
+				var field = fieldsToInject[i];
+				var attr = ServiceKitReflectionCache.GetInjectAttribute(field);
+				if (_serviceKitLocator.TryResolveService(field.FieldType, out var service) != ServiceResolutionStatus.Ready)
+				{
+					return false;
+				}
+				results[i] = (field, service, attr.Required);
+			}
+			return true;
+		}
+
+		private void AssignResolvedFields((FieldInfo field, object service, bool required)[] results)
+		{
+			for (var i = 0; i < results.Length; i++)
+			{
+				var (field, service, _) = results[i];
+				if (field == null) continue;
+				field.SetValue(_target, service);
+			}
+		}
+
 #if SERVICEKIT_UNITASK
 		private async UniTask<(FieldInfo field, object service, bool required)[]> ResolveAllServicesInParallel(
-			List<FieldInfo> fieldsToInject,
+			IReadOnlyList<FieldInfo> fieldsToInject,
 			CancellationToken cancellationToken,
 			CancellationTokenSource resolutionCts,
 			CancellationTokenSource timeoutCts,
@@ -245,7 +300,7 @@ namespace Nonatomic.ServiceKit
 		}
 #else
 		private async Task<(FieldInfo field, object service, bool required)[]> ResolveAllServicesInParallel(
-			List<FieldInfo> fieldsToInject,
+			IReadOnlyList<FieldInfo> fieldsToInject,
 			CancellationToken cancellationToken,
 			CancellationTokenSource resolutionCts,
 			CancellationTokenSource timeoutCts,
@@ -303,19 +358,34 @@ namespace Nonatomic.ServiceKit
 
 		private void ThrowIfRequiredServicesAreMissing((FieldInfo field, object service, bool required)[] results)
 		{
-			var missingRequiredServices = results
-				.Where(r => r.field != null && r.service == null && r.required)
-				.Select(r => r.field.FieldType.Name)
-				.ToArray();
+			// Happy-path scan: allocate nothing unless a required service is actually missing.
+			var anyMissing = false;
+			for (var i = 0; i < results.Length; i++)
+			{
+				var r = results[i];
+				if (r.field != null && r.service == null && r.required)
+				{
+					anyMissing = true;
+					break;
+				}
+			}
 
-			if (missingRequiredServices.Length == 0)
+			if (!anyMissing)
 				return;
 
 			var sb = ServiceKitObjectPool.RentStringBuilder();
 			try
 			{
 				sb.Append("Required services not available: ");
-				sb.Append(string.Join(", ", missingRequiredServices));
+				var first = true;
+				for (var i = 0; i < results.Length; i++)
+				{
+					var r = results[i];
+					if (r.field == null || r.service != null || !r.required) continue;
+					if (!first) sb.Append(", ");
+					sb.Append(r.field.FieldType.Name);
+					first = false;
+				}
 				throw new ServiceInjectionException(sb.ToString());
 			}
 			finally
@@ -443,6 +513,11 @@ namespace Nonatomic.ServiceKit
 #else
 		private async Task WaitForAwakePhaseCompletion()
 		{
+			// Mirror the UniTask path: edit mode has no Awake phase to wait for, so skip the defer. Unlike
+			// UniTask.NextFrame, Task.Delay does resume in edit mode, so this is a consistency/perf tidy
+			// rather than a hang fix - but it keeps the two paths behaviourally aligned.
+			if (!ServiceKitRuntimeState.IsPlaying) return;
+
 			// Yield to allow other Awake calls to complete registration.
 			// Task.Yield doesn't properly defer in Unity Edit Mode, so we use Task.Delay
 			// as a fallback. This is imprecise but sufficient since we re-check atomically after.
@@ -470,8 +545,10 @@ namespace Nonatomic.ServiceKit
 
 		private bool ShouldIgnoreCancellation(bool isExplicitTimeout)
 		{
-			// Ignore cancellation if it's from application quit and not an explicit timeout or user cancellation
-			return !isExplicitTimeout && !_cancellationToken.IsCancellationRequested && !Application.isPlaying;
+			// Ignore cancellation if it's from application quit and not an explicit timeout or user cancellation.
+			// ServiceKitRuntimeState.IsPlaying (not Application.isPlaying) so this is safe if the continuation
+			// resumed off the main thread.
+			return !isExplicitTimeout && !_cancellationToken.IsCancellationRequested && !ServiceKitRuntimeState.IsPlaying;
 		}
 
 		private ServiceInjectionFailureKind ClassifyCancellation(Exception exception, bool isExplicitTimeout)
@@ -511,7 +588,7 @@ namespace Nonatomic.ServiceKit
 			return ServiceInjectionFailureKind.ServiceUnregistered;
 		}
 
-		private ServiceInjectionTimeoutException BuildInjectionException(List<FieldInfo> fieldsToInject, ServiceInjectionFailureKind kind)
+		private ServiceInjectionTimeoutException BuildInjectionException(IReadOnlyList<FieldInfo> fieldsToInject, ServiceInjectionFailureKind kind)
 		{
 			var sb = ServiceKitObjectPool.RentStringBuilder();
 			try
@@ -598,7 +675,7 @@ namespace Nonatomic.ServiceKit
 			return sb.ToString();
 		}
 
-		private void AppendWaitingServices(StringBuilder sb, List<FieldInfo> fieldsToInject)
+		private void AppendWaitingServices(StringBuilder sb, IReadOnlyList<FieldInfo> fieldsToInject)
 		{
 			var hasMissing = false;
 

--- a/Runtime/ServiceKitRuntimeState.cs
+++ b/Runtime/ServiceKitRuntimeState.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -6,24 +7,47 @@ using UnityEditor;
 namespace Nonatomic.ServiceKit
 {
 	/// <summary>
-	/// Thread-safe snapshot of whether the player is running. <see cref="Application.isPlaying"/> may
-	/// only be read on the main thread, but async injection continuations can resume on a worker thread
-	/// (e.g. when a consumer awaits the injection with <c>ConfigureAwait(false)</c>). This caches the
-	/// state on the main thread via Unity lifecycle hooks so injection code can read it from anywhere
-	/// without throwing.
+	/// Thread-safe snapshots of Unity main-thread state. <see cref="Application.isPlaying"/> may only be
+	/// read on the main thread, and the Unity <see cref="SynchronizationContext"/> is only discoverable
+	/// there - but async injection continuations can resume on a worker thread (e.g. when a consumer
+	/// awaits the injection with <c>ConfigureAwait(false)</c>, or starts it off the main thread). This
+	/// caches both on the main thread via Unity lifecycle hooks so injection code can read them from
+	/// anywhere without throwing, and marshal back onto the main thread when it needs to.
 	/// </summary>
 	internal static class ServiceKitRuntimeState
 	{
 		// volatile so writes from the main thread are visible to a reader on a worker thread.
 		private static volatile bool _isPlaying;
+		private static volatile SynchronizationContext _unityContext;
 
 		/// <summary>True in a player build and in editor play mode; false in editor edit mode.</summary>
 		public static bool IsPlaying => _isPlaying;
 
+		/// <summary>
+		/// The Unity main-thread <see cref="SynchronizationContext"/>, captured on the main thread. Lets
+		/// injection marshal a continuation back onto the main thread even when it was started off the
+		/// main thread (where <c>SynchronizationContext.Current</c> is null). Null only before the first
+		/// main-thread injection in a runtime that never had a context (e.g. some headless tests).
+		/// </summary>
+		public static SynchronizationContext UnityContext => _unityContext;
+
+		/// <summary>Records the Unity context the first time a non-null one is seen on the main thread.</summary>
+		internal static void CaptureUnityContext(SynchronizationContext context)
+		{
+			if (_unityContext == null && context != null)
+			{
+				_unityContext = context;
+			}
+		}
+
 		// Runs when the player loop starts (both in builds and on entering editor play mode), and before
-		// any scene loads. In edit mode it never runs, so the field stays false there.
+		// any scene loads. In edit mode it never runs, so the flag stays false there.
 		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-		private static void OnRuntimeLoad() => _isPlaying = true;
+		private static void OnRuntimeLoad()
+		{
+			_isPlaying = true;
+			CaptureUnityContext(SynchronizationContext.Current);
+		}
 
 #if UNITY_EDITOR
 		// Keeps the flag correct across play-mode transitions in the interactive editor, where the static

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.nonatomic.servicekit",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "displayName": "Service Kit",
   "description": "A lightweight dependency injection and service locator framework for Unity. Attribute-based registration, async resolution, fluent API, optional dependencies, service tags, scene-aware lifecycle, and UniTask support.",
   "unity": "2022.3",


### PR DESCRIPTION
## 2.6.0 — review follow-ups: injection perf, locator facets, off-thread fix

Follow-through on a SOLID / performance / cross-platform review. README accuracy fixes ride along.

### Performance — faster steady-state injection
- **Synchronous fast path.** When every dependency of an object is already ready (and injection is on the Unity thread), resolution and assignment happen inline — skipping the per-field `async` state machines, the `Task[]` + `WhenAll`, and the thread hop. This is the dominant case when instantiating injected prefabs after startup. It triggers *only* when all dependencies are already `Ready`, so it is semantically identical to the async path resolving them immediately; anything not-yet-ready falls through to the existing async path.
- **Build dependency-graph edges once per type** instead of on every injection (they are derived from the type's immutable injectable fields), removing per-spawn dictionary churn under the graph lock.
- **No allocation on the success path** of the required-services check (early-exit loop instead of LINQ) or the circular-dependency check (the `CircularDependencyInfo` + path copy are deferred until a cycle is actually found), and the cached `FieldInfo[]` is passed through read-only instead of copied into a `List` per injection.

### Extensibility — locator interface facets
`IServiceKitLocator` is decomposed into focused interfaces it now inherits:
- `IServiceLocator` — core register / ready / resolve / inject
- `IServiceTagRegistry` — tag assignment + queries
- `IServiceSceneManager` — scene-scoped lifecycle
- `IServiceDiagnostics` — inspection, status, circular-dependency state

**Additive and non-breaking:** `IServiceKitLocator` exposes the same full surface via inheritance, the concrete `ServiceKitLocator` is unchanged (implicit implementations satisfy the facets), and existing implementers keep compiling. New code and alternative locators can now depend on just the slice they need.

### Correctness — off-thread failure path
The injection failure path could call main-thread-only Unity APIs (`Application.isPlaying`, the destroyed-target `== null` check, hierarchy/scene description) on a worker thread when an injection was started off the main thread or resumed there via `ConfigureAwait(false)` — throwing a `UnityException`. The `catch` now re-syncs to the Unity thread (via a globally-captured context) before any Unity-API access, and play-state is read from the thread-safe `ServiceKitRuntimeState` snapshot. The edit-mode defer is now consistent across the UniTask and `Task` paths.

### README accuracy
Official Cysharp UniTask install URL (`...UniTask#2.5.10`) + removed a corrupted `sw.js` link artifact; documented the typed exceptions (`ServiceInjectionTimeoutException` / `ServiceUnregisteredException`) and the 30s default timeout; corrected the `IServiceInjectionBuilder` API reference (`Execute()` is class-only, not on the interface; added the missing members); fixed the optional-dependency example to show the injection trigger.

### Validation
Full suites, both configurations, Unity 6000.3.16f1:

| Config | EditMode | PlayMode |
| --- | --- | --- |
| Default (no UniTask) | 113 / 113 | 19 / 19 |
| UniTask 2.5.10 | 111 / 111 | 19 / 19 |
