### PR TITLE
Audit fixes: 2.6.0 graph regression, correctness, README honesty (2.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2.6.1] - 2026-06-08
+
+### Fixed
+- **Dependency-graph edges weren't reset on unregister** (regression from 2.6.0's once-per-type edge caching). Re-registering a service type with a different concrete implementation — common across a scene reload — kept the previous type's dependency edges, so circular-dependency detection could miss a real cycle or report a phantom one. Unregister now invalidates the node.
+- **`CleanupDestroyedServices` left pending awaiters hanging.** Unlike the other teardown paths, it removed services without faulting their awaiters, so a consumer awaiting a now-destroyed service hung until timeout. It now faults them with `ServiceUnregisteredException`.
+- **`ServiceKitBehaviour`'s registration guard is reset on unregister**, so a pooled/reused object re-registers via `UseLocator()` as documented instead of being silently skipped on its second lifecycle.
+- **Off-thread injection with a timeout no longer throws a Unity main-thread exception** — injection hops to the Unity thread before creating the timeout manager (which calls `new GameObject` / reads `Time.*`).
+- **`WarnOnDestroyedRegistration` now works.** The setting was never read; registering a destroyed `UnityEngine.Object` now logs a warning when it is enabled (default on).
+
+### Changed
+- **README accuracy.** Removed the reference to a benchmark suite that does not ship and reframed the indicative timings honestly; softened "zero allocations" to "greatly reduced allocations" (UniTask is allocation-free, ServiceKit's wrapper is not); reworded "race-condition-free optional resolution" to match what the atomic check actually guarantees. Documented the interface facets, the `ServiceKitExtensions` convenience methods, the `ServiceKitSettings` fields, and the `ServiceInjectionFailureKind` values; added a class summary to `ServiceKitLocator`. Removed a leftover editor console-log block.
+
 ## [2.6.0] - 2026-06-07
 
 ### Added

--- a/Editor/ServiceKitWindow/ServiceKitServicesTab.cs
+++ b/Editor/ServiceKitWindow/ServiceKitServicesTab.cs
@@ -399,26 +399,16 @@ namespace Nonatomic.ServiceKit.Editor.ServiceKitWindow
 			{
 				// Check if there's a configured default in ServiceKitSettings
 				var configuredDefault = PropertyDrawer.ServiceKitLocatorDrawer.GetStaticPriorityBasedDefaultLocator();
-				
-				Debug.Log($"[ServiceKit Debug] ServiceKitServicesTab - No persisted selection, checking configured default");
-				Debug.Log($"[ServiceKit Debug] Configured default: {(configuredDefault != null ? configuredDefault.name : "null")}");
-				Debug.Log($"[ServiceKit Debug] Ordered locators count: {_orderedLocators.Count}");
-				if (_orderedLocators.Count > 0)
-				{
-					Debug.Log($"[ServiceKit Debug] First ordered locator: {_orderedLocators[0].name}");
-				}
-				
+
 				if (configuredDefault != null && _orderedLocators.Contains(configuredDefault))
 				{
 					// Use the configured default
 					locatorToSelect = configuredDefault;
-					Debug.Log($"[ServiceKit Debug] Using configured default: {configuredDefault.name}");
 				}
 				else
 				{
 					// Fall back to first item (which is sorted by priority already)
 					locatorToSelect = _orderedLocators[0];
-					Debug.Log($"[ServiceKit Debug] Using first ordered locator: {locatorToSelect.name}");
 				}
 			}
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ https://www.pkglnk.dev/servicekit.git
 -   **ScriptableObject-Based**: Clean, asset-based architecture that integrates seamlessly with Unity's workflow.
 -   **Multi-Phase Initialization**: A robust, automated lifecycle ensures services are registered, injected, and initialized safely.
 -   **Async Service Resolution**: Wait for services to become fully ready with cancellation and timeout support.
--   **Atomic 3-State Resolution**: Race-condition-free optional dependency resolution distinguishes ready, registered-but-not-ready, and absent services in a single atomic check.
--   **UniTask Integration**: Automatic performance optimization when [UniTask](https://github.com/Cysharp/UniTask) is available - zero allocations and faster async operations.
+-   **Atomic 3-State Resolution**: Each optional-dependency check is a single lock-guarded atomic operation distinguishing ready, registered-but-not-ready, and absent services (the optional-wait flow re-checks atomically across frames to catch late registrations).
+-   **UniTask Integration**: Automatic performance optimization when [UniTask](https://github.com/Cysharp/UniTask) is available - greatly reduced allocations and faster async operations.
 -   **Fluent Dependency Injection**: Elegant builder pattern for configuring service injection.
 -   **Automatic Scene Management**: Services are automatically tracked and cleaned up when scenes unload.
 -   **Comprehensive Debugging**: Built-in editor window with search, filtering, and service inspection.
@@ -300,7 +300,7 @@ ServiceKit automatically detects when UniTask is available and seamlessly switch
 // Same code, different performance characteristics:
 await serviceKit.GetServiceAsync<IPlayerService>();
 
-// With UniTask installed:   → Zero allocations, faster execution
+// With UniTask installed:   → Fewer allocations, faster execution
 // Without UniTask:          → Standard Task performance
 ```
 
@@ -321,9 +321,9 @@ https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2
 
 When UniTask is available, ServiceKit automatically provides:
 
-- **🚀 2-3x Faster Async Operations**: For immediately completing operations
-- **📉 50-80% Less Memory Allocation**: Reduced GC pressure and frame drops
-- **⚡ Zero-Allocation Async**: Most async operations produce no garbage
+- **🚀 Faster Async Operations**: Especially for operations that complete immediately
+- **📉 Less Memory Allocation**: Reduced GC pressure and frame drops
+- **⚡ Lower-Allocation Async**: UniTask itself is allocation-free; ServiceKit's async path allocates far less than on the Task path (not strictly zero — a small per-call buffer remains)
 - **🎯 Unity-Optimized**: Better main thread synchronization and PlayerLoop integration
 
 ### Usage Examples
@@ -466,7 +466,8 @@ public class PlayerController : ServiceKitBehaviour, IPlayerController
         // The exception is typed: a timeout arrives as ServiceInjectionTimeoutException (a
         // TimeoutException) and an unregistered service as ServiceUnregisteredException (an
         // OperationCanceledException). Both subclass their base type, so the checks below keep
-        // working; both also carry a .Kind discriminator if you need to branch precisely.
+        // working; both also carry a .Kind discriminator (ServiceInjectionFailureKind:
+        // Timeout, CallerCanceled, ServiceUnregistered, TargetDestroyed) if you need to branch precisely.
         if (exception is TimeoutException)
         {
             Debug.Log("Services took too long to become available");
@@ -763,6 +764,8 @@ IServiceRegistrationBuilder Register<T>(T service) where T : class;
 IServiceRegistrationBuilder Register(object service);
 
 // Direct Registration
+// (registration methods also take a trailing optional [CallerMemberName] string registeredBy,
+//  auto-filled for debug attribution - you normally omit it)
 void RegisterService<T>(T service) where T : class;
 void RegisterService(Type serviceType, object service);
 void RegisterAndReadyService<T>(T service) where T : class;
@@ -825,6 +828,57 @@ Task ExecuteWithCancellationAsync(CancellationToken token);    // Awaitable, app
 // ServiceInjectionBuilder for advanced use; prefer the awaitable ExecuteAsync above.
 ```
 
+### Convenience Extensions
+
+`ServiceKitExtensions` adds ergonomic helpers on top of `IServiceKitLocator`:
+
+```csharp
+// One-line injection (default timeout + cancellation + error handling)
+await serviceKit.InjectAsync(this, destroyCancellationToken);
+
+// Check whether a ready service exists
+if (serviceKit.HasService<IPlayerService>()) { /* ... */ }
+
+// Run an action only if the service is available (no-op otherwise)
+serviceKit.WithService<IAudioService>(audio => audio.Play(clip));
+
+// ...or return a value, with a fallback when the service is absent
+var volume = serviceKit.WithService<IAudioService, float>(audio => audio.Volume, 1f);
+
+// Register from a factory, or from an async source (Task<T> / UniTask<T>)
+serviceKit.RegisterServiceFactory<IPlayerService>(() => new PlayerService());
+await serviceKit.RegisterServiceAsync(LoadPlayerServiceAsync());
+```
+
+### Locator Interface Facets
+
+`IServiceKitLocator` is composed from four smaller interfaces, so code (and alternative locator implementations) can depend on only the slice it needs:
+
+| Interface | Responsibility |
+|-----------|----------------|
+| `IServiceLocator` | Core: register, ready, resolve, inject |
+| `IServiceTagRegistry` | Tag assignment and tag-based queries |
+| `IServiceSceneManager` | Scene-scoped enumeration and cleanup |
+| `IServiceDiagnostics` | Inspection, status, circular-dependency state |
+
+`IServiceKitLocator` inherits all four, so existing code is unaffected. To point a `ServiceKitBehaviour` at your own locator, override `ResolveLocator()`:
+
+```csharp
+protected override IServiceKitLocator ResolveLocator() => MyCustomLocator.Instance;
+```
+
+### ServiceKit Settings
+
+Create a settings asset via `Assets > Create > ServiceKit > Settings` (loaded from a `Resources` folder at runtime, auto-discovered in the editor):
+
+| Setting | Default | Effect |
+|---------|---------|--------|
+| `DefaultTimeout` | `30` | Seconds `WithTimeout()` waits before failing |
+| `AutoCleanupOnSceneUnload` | `true` | Unregister scene `MonoBehaviour` services when their scene unloads |
+| `WarnOnDestroyedRegistration` | `true` | Log a warning when a destroyed object is registered |
+| `DebugLogging` | `false` | Verbose registration/ready logging (editor) |
+| `DefaultServiceKitLocator` | — | Locator used for auto-assignment; takes highest priority |
+
 ## Best Practices
 
 ### Service Design
@@ -854,9 +908,9 @@ Task ExecuteWithCancellationAsync(CancellationToken token);    // Awaitable, app
 * **Batch service resolution** when possible using `UniTask.WhenAll()` or `Task.WhenAll()`.
 * **Profile on target platforms** - UniTask benefits are most noticeable on mobile and lower-end devices.
 
-## Benchmark Performance
+## Indicative Performance
 
-All core service operations complete in sub-millisecond time. These numbers were measured in the Unity Editor (development build) and will be faster in release builds.
+The tables below are **indicative** timings from a single Unity Editor session (development build) on one machine — a rough guide, not a bundled or reproducible benchmark. Release builds are faster, and absolute numbers vary widely by hardware, so treat these as ballpark figures and profile your own target platform.
 
 ### Service Resolution
 
@@ -888,7 +942,7 @@ All core service operations complete in sub-millisecond time. These numbers were
 | 50 concurrent accessors x 20 services | 36.818ms |
 | 1000x register/unregister cycle | 1867.780ms |
 
-All core operations are well within frame budget for 60fps+ applications. Results will vary by hardware — run the included benchmark suite via `Window > General > Test Runner` to validate on your setup.
+All core operations are well within frame budget for 60fps+ applications. ServiceKit does not bundle a benchmark suite — use the Unity Profiler on your target platform to measure your own setup.
 
 ### Performance Tips
 

--- a/Runtime/ServiceDependencyGraph.cs
+++ b/Runtime/ServiceDependencyGraph.cs
@@ -60,6 +60,25 @@ namespace Nonatomic.ServiceKit
 			UpdateForTarget(serviceType, fieldsToInject);
 		}
 
+		/// <summary>
+		/// Resets a node's dependency edges so they are rebuilt on the next registration/injection. Must be
+		/// called when a service type is unregistered: the edges were derived from the previously-registered
+		/// concrete type's fields, and a different concrete registered under the same key (e.g. across a
+		/// scene reload) would otherwise inherit stale edges and mis-detect circular dependencies.
+		/// </summary>
+		public void InvalidateTarget(Type serviceType)
+		{
+			lock (_graphLock)
+			{
+				if (_dependencyGraph.TryGetValue(serviceType, out var node))
+				{
+					node.Dependencies.Clear();
+					node.DependencyFields.Clear();
+					node.DependenciesPopulated = false;
+				}
+			}
+		}
+
 		public CircularDependencyInfo DetectCircularDependency(Type root)
 		{
 			lock (_graphLock)

--- a/Runtime/ServiceInjectionBuilder.cs
+++ b/Runtime/ServiceInjectionBuilder.cs
@@ -153,6 +153,11 @@ namespace Nonatomic.ServiceKit
 					return;
 				}
 
+				// Past the fast path we take the async route. If this injection was started off the main
+				// thread, get onto it now: the timeout manager creates a GameObject and reads Time.*, both
+				// main-thread-only. No-op when already on the Unity thread (the common case).
+				await ServiceKitThreading.SwitchToUnityThread(unityContext);
+
 				if (_timeout > 0f)
 				{
 					timeoutCts = new CancellationTokenSource();

--- a/Runtime/ServiceKitBehaviour.cs
+++ b/Runtime/ServiceKitBehaviour.cs
@@ -245,6 +245,11 @@ namespace Nonatomic.ServiceKit
 		{
 			MarkAsUnregistered();
 			MarkAsNotReady();
+
+			// Reset the double-registration guard so a later UseLocator()/re-registration can run again
+			// (e.g. a pooled object revived after OnDestroy unregistered it). Without this the guard stays
+			// latched at 1 and the re-registration UseLocator() promises is silently skipped.
+			Interlocked.Exchange(ref _registrationGuard, 0);
 		}
 
 		private void MarkAsUnregistered()

--- a/Runtime/ServiceKitLocator.cs
+++ b/Runtime/ServiceKitLocator.cs
@@ -25,6 +25,13 @@ namespace Nonatomic.ServiceKit
 		NotRegistered
 	}
 
+	/// <summary>
+	/// The default <see cref="IServiceKitLocator"/> - a <see cref="ScriptableObject"/> asset that holds the
+	/// registered services for a project or scene. Create one via <c>Assets &gt; Create &gt; ServiceKit &gt;
+	/// ServiceKitLocator</c> and assign it to a <see cref="ServiceKitBehaviour"/>'s serialized field (or any
+	/// <c>[SerializeField] ServiceKitLocator</c>). Multiple locators can coexist; each owns its own service
+	/// registry and dependency graph.
+	/// </summary>
 	[CreateAssetMenu(fileName = "ServiceKit", menuName = "ServiceKit/ServiceKitLocator")]
 	public class ServiceKitLocator : ScriptableObject, IServiceKitLocator
 	{
@@ -104,6 +111,16 @@ namespace Nonatomic.ServiceKit
 		private void RegisterServiceInternal(Type serviceType, object service, bool exemptFromCircularDependencyCheck, ServiceTag[] tags, [CallerMemberName] string registeredBy = null)
 		{
 			ValidateServiceNotNull(serviceType, service, registeredBy);
+
+			// A destroyed UnityEngine.Object passes the null check above (it is not reference-null) but is
+			// unusable; warn so the bug is visible at registration instead of surfacing later as a null
+			// dependency. Governed by the ServiceKitSettings.WarnOnDestroyedRegistration toggle (default on).
+			if (ServiceKitSettings.Instance.WarnOnDestroyedRegistration && service is UnityEngine.Object destroyedObject && destroyedObject == null)
+			{
+				Debug.LogWarning($"[ServiceKit] Registering '{serviceType.Name}'" +
+					(registeredBy != null ? $" by '{registeredBy}'" : string.Empty) +
+					" from a destroyed object; it is registered but will not be usable.");
+			}
 
 			lock (_lock)
 			{
@@ -546,6 +563,7 @@ namespace Nonatomic.ServiceKit
 				var removed = _readyServices.Remove(serviceType) || _registeredServices.Remove(serviceType);
 
 				_dependencyGraph.RemoveCircularDependencyExemption(serviceType);
+				_dependencyGraph.InvalidateTarget(serviceType);
 
 #if UNITY_EDITOR
 				if (removed && ServiceKitSettings.Instance.DebugLogging)
@@ -727,6 +745,7 @@ namespace Nonatomic.ServiceKit
 				{
 					_readyServices.Remove(type);
 					_registeredServices.Remove(type);
+					_dependencyGraph.InvalidateTarget(type);
 
 					if (_serviceAwaiters.TryGetValue(type, out var tcs))
 					{
@@ -764,6 +783,12 @@ namespace Nonatomic.ServiceKit
 
 		public void CleanupDestroyedServices()
 		{
+#if SERVICEKIT_UNITASK
+			var awaitersToCancel = new List<(Type type, UniTaskCompletionSource<object> tcs)>();
+#else
+			var awaitersToCancel = new List<(Type type, TaskCompletionSource<object> tcs)>();
+#endif
+
 			lock (_lock)
 			{
 				var servicesToRemove = new List<Type>();
@@ -788,8 +813,22 @@ namespace Nonatomic.ServiceKit
 				{
 					_readyServices.Remove(type);
 					_registeredServices.Remove(type);
+					_dependencyGraph.InvalidateTarget(type);
 
+					// Fault any pending awaiter so a consumer waiting on a now-destroyed service doesn't
+					// hang until timeout - matching UnregisterService / UnregisterServicesFromScene.
+					if (_serviceAwaiters.TryGetValue(type, out var tcs))
+					{
+						_serviceAwaiters.Remove(type);
+						awaitersToCancel.Add((type, tcs));
+					}
 				}
+			}
+
+			// Fault outside the lock so awaiter continuations never run while _lock is held.
+			foreach (var (type, tcs) in awaitersToCancel)
+			{
+				tcs.TrySetException(new ServiceUnregisteredException(type));
 			}
 		}
 

--- a/Tests/EditMode/DependencyGraphIsolationTests.cs
+++ b/Tests/EditMode/DependencyGraphIsolationTests.cs
@@ -18,6 +18,16 @@ namespace Tests.EditMode
 		public class Foo : IFoo { }
 		public class Bar : IBar { }
 
+		// Used by the re-registration regression test below.
+		public interface ICyclicA { }
+		public interface ICyclicB { }
+		public class PlainA : ICyclicA { }
+		public class PlainB : ICyclicB { }
+#pragma warning disable 0169 // injected fields are written by reflection, never read here
+		public class CyclicA : ICyclicA { [InjectService] private ICyclicB _b; }
+		public class CyclicB : ICyclicB { [InjectService] private ICyclicA _a; }
+#pragma warning restore 0169
+
 		private ServiceKitLocator _locatorA;
 		private ServiceKitLocator _locatorB;
 
@@ -68,6 +78,28 @@ namespace Tests.EditMode
 				"Locator A's exemption should be gone after ClearServices");
 			Assert.IsTrue(_locatorB.IsServiceCircularDependencyExempt<IBar>(),
 				"Clearing locator A must not clear locator B's exemption");
+		}
+
+		[Test]
+		public void Reregistering_DifferentImpl_RebuildsDependencyEdges()
+		{
+			// Dependency-free implementations first: no cycle, the graph nodes hold empty edges.
+			_locatorA.RegisterAndReadyService<ICyclicA>(new PlainA());
+			_locatorA.RegisterAndReadyService<ICyclicB>(new PlainB());
+			Assert.IsFalse(_locatorA.HasCircularDependencyError<ICyclicB>(),
+				"Dependency-free services should not produce a circular-dependency error");
+
+			// Unregister both, then re-register implementations that DO form a cycle. Before the
+			// graph-invalidation fix, UnregisterService left the gated (empty) node edges in place, so
+			// the re-registration skipped the rebuild and silently missed this cycle.
+			_locatorA.UnregisterService<ICyclicA>();
+			_locatorA.UnregisterService<ICyclicB>();
+
+			_locatorA.RegisterService<ICyclicA>(new CyclicA());
+			_locatorA.RegisterService<ICyclicB>(new CyclicB());
+
+			Assert.IsTrue(_locatorA.HasCircularDependencyError<ICyclicB>(),
+				"Re-registered cyclic services must be detected; stale graph edges would miss the cycle");
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.nonatomic.servicekit",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "displayName": "Service Kit",
   "description": "A lightweight dependency injection and service locator framework for Unity. Attribute-based registration, async resolution, fluent API, optional dependencies, service tags, scene-aware lifecycle, and UniTask support.",
   "unity": "2022.3",


### PR DESCRIPTION
## 2.6.1 — audit fixes: a 2.6.0 regression, correctness, README honesty, docs

Follow-up to a code-review / README-accuracy / over-promise / incomplete-feature audit. All findings verified against the code before fixing.

### Fixed
- **Dependency-graph regression from 2.6.0.** The once-per-type edge cache (`DependenciesPopulated`) wasn't invalidated on unregister, so re-registering a service type with a *different* concrete (common on scene reload) kept the old type's dependency edges — circular detection could then miss a real cycle or report a phantom one. `UnregisterService` / `UnregisterServicesFromScene` / `CleanupDestroyedServices` now invalidate the node. Covered by a new regression test (`Reregistering_DifferentImpl_RebuildsDependencyEdges`).
- **`CleanupDestroyedServices` left awaiters hanging** — it removed services without faulting their pending `GetServiceAsync` awaiters, so a consumer hung until timeout. Now faults them like every other teardown path.
- **Registration guard never reset.** `ServiceKitBehaviour._registrationGuard` latched at 1 and was never cleared, so a pooled/reused object's second `UseLocator()` registration was silently dropped — contradicting the `UseLocator` doc. Reset on unregister.
- **Off-thread injection + timeout** threw a `UnityException` (the timeout manager calls `new GameObject` / reads `Time.*`). Injection now hops to the Unity thread before the timeout setup.
- **`WarnOnDestroyedRegistration` did nothing** — the setting was never read. Now honored (registering a destroyed `UnityEngine.Object` logs a warning; default on).

### Changed — README honesty + docs
- Removed the reference to a **benchmark suite that doesn't ship** and reframed the indicative timings honestly.
- "Zero allocations" → "greatly reduced allocations" (UniTask is allocation-free; ServiceKit's wrapper still allocates a small per-call buffer). "Race-condition-free optional resolution" reworded to match what the atomic check actually guarantees.
- Documented the **interface facets**, the **`ServiceKitExtensions`** convenience methods, the **`ServiceKitSettings`** fields, and the **`ServiceInjectionFailureKind`** values; added a class summary to the concrete `ServiceKitLocator`. Removed a leftover editor console-log block.

### Validation
| Config | EditMode | PlayMode |
| --- | --- | --- |
| Default (no UniTask) | 114 / 114 | 19 / 19 |
| UniTask 2.5.10 | 112 / 112 | 19 / 19 |
