### PR TITLE
Narrow injection surface to core IServiceLocator (3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [3.0.0] - 2026-06-08
+
+### Changed
+- **Breaking: the injection engine and `ServiceKitBehaviour` now depend on the core `IServiceLocator` facet rather than the full `IServiceKitLocator`.** `ServiceKitBehaviour.ResolveLocator()` returns `IServiceLocator` and `UseLocator()` accepts one, so a **custom locator only has to implement the core register / ready / resolve / inject surface** — not the tag, scene, and diagnostics facets it may not need. `ServiceInjectionBuilder`, `ServiceRegistrationBuilder`, and the `ServiceKitExtensions` helpers were narrowed to `IServiceLocator` too. `IServiceKitLocator` still inherits all four facets, and the concrete `ServiceKitLocator` is unchanged.
+
+### Migration
+- **The common path is unaffected.** A serialized `ServiceKitLocator` field, `UseLocator(someServiceKitLocator)`, and overriding `ResolveLocator()` to return an `IServiceKitLocator` all keep compiling — the concrete type satisfies the narrower signatures and covariant returns cover the override.
+- **The one break:** a `ServiceKitBehaviour` subclass that calls a tag / scene / diagnostics member *through* `Locator` (e.g. `Locator.AddTagsToService(...)`, `Locator.GetServicesWithTag(...)`) must now cast, since `Locator` is the core facet: `((IServiceKitLocator)Locator).AddTagsToService(...)`. The Complete Game Example sample was updated to show this.
+
 ## [2.6.1] - 2026-06-08
 
 ### Fixed

--- a/Runtime/ServiceInjectionBuilder.cs
+++ b/Runtime/ServiceInjectionBuilder.cs
@@ -21,16 +21,16 @@ namespace Nonatomic.ServiceKit
 	/// </summary>
 	public class ServiceInjectionBuilder : IServiceInjectionBuilder
 	{
-		public ServiceInjectionBuilder(IServiceKitLocator serviceKitLocator, object target)
+		public ServiceInjectionBuilder(IServiceLocator serviceKitLocator, object target)
 			// Fallback for external callers: only the concrete locator owns a dependency graph.
 			: this(serviceKitLocator, target, (serviceKitLocator as ServiceKitLocator)?.DependencyGraph)
 		{
 		}
 
 		// The concrete locator passes its graph in directly (see ServiceKitLocator.Inject) rather than
-		// having it re-discovered via a downcast. An alternative IServiceKitLocator simply has no graph
+		// having it re-discovered via a downcast. An alternative IServiceLocator simply has no graph
 		// and circular-dependency bookkeeping is skipped.
-		internal ServiceInjectionBuilder(IServiceKitLocator serviceKitLocator, object target, ServiceDependencyGraph dependencyGraph)
+		internal ServiceInjectionBuilder(IServiceLocator serviceKitLocator, object target, ServiceDependencyGraph dependencyGraph)
 		{
 			_serviceKitLocator = serviceKitLocator;
 			_target = target;
@@ -777,7 +777,7 @@ namespace Nonatomic.ServiceKit
 		[SerializeField]
 		private float _timeout = -1f;
 
-		private readonly IServiceKitLocator _serviceKitLocator;
+		private readonly IServiceLocator _serviceKitLocator;
 		private readonly ServiceDependencyGraph _dependencyGraph;
 		private readonly object _target;
 		private readonly Type _targetServiceType;

--- a/Runtime/ServiceKitBehaviour.cs
+++ b/Runtime/ServiceKitBehaviour.cs
@@ -25,7 +25,7 @@ namespace Nonatomic.ServiceKit
 	{
 		[SerializeField] public ServiceKitLocator ServiceKitLocator;
 
-		private IServiceKitLocator _locatorOverride;
+		private IServiceLocator _locatorOverride;
 		private Type[] _cachedServiceTypes;
 		private bool _isCircularDependencyExempt;
 		private int _registrationGuard;
@@ -33,24 +33,25 @@ namespace Nonatomic.ServiceKit
 		/// <summary>
 		/// Returns the active service locator. Uses the override if set, otherwise falls back to the serialized field.
 		/// </summary>
-		protected IServiceKitLocator Locator => ResolveLocator();
+		protected IServiceLocator Locator => ResolveLocator();
 
 		/// <summary>
 		/// Resolves the active service locator. Override this to supply a locator from a custom source
 		/// (e.g. a global registry, a parent component, or an addressable) instead of the serialized
-		/// field - the serialized field cannot be typed as the interface, so this is the extension
-		/// point for alternative <see cref="IServiceKitLocator"/> implementations. Defaults to the
-		/// UseLocator() override if set, otherwise the serialized ServiceKitLocator field.
+		/// field - the serialized field cannot be typed as the interface, so this is the extension point
+		/// for alternative locators. It returns the core <see cref="IServiceLocator"/>, so a custom
+		/// implementation only needs that facet, not the full <see cref="IServiceKitLocator"/>. Defaults
+		/// to the UseLocator() override if set, otherwise the serialized ServiceKitLocator field.
 		/// </summary>
-		protected virtual IServiceKitLocator ResolveLocator() => _locatorOverride ?? ServiceKitLocator;
+		protected virtual IServiceLocator ResolveLocator() => _locatorOverride ?? ServiceKitLocator;
 
 		/// <summary>
 		/// Sets an override for the ServiceKitLocator. Useful for unit testing with mocks.
 		/// If Awake() already ran but registration was skipped due to missing locator,
 		/// this method will trigger registration automatically.
 		/// </summary>
-		/// <param name="locator">The IServiceKitLocator to use (can be a mock)</param>
-		public void UseLocator(IServiceKitLocator locator)
+		/// <param name="locator">The IServiceLocator to use (can be a mock or a custom implementation)</param>
+		public void UseLocator(IServiceLocator locator)
 		{
 			_locatorOverride = locator;
 

--- a/Runtime/ServiceKitExtensions.cs
+++ b/Runtime/ServiceKitExtensions.cs
@@ -16,9 +16,9 @@ namespace Nonatomic.ServiceKit
 		/// most injection scenarios.
 		/// </summary>
 #if SERVICEKIT_UNITASK
-		public static UniTask InjectAsync(this IServiceKitLocator locator, object target, CancellationToken cancellationToken)
+		public static UniTask InjectAsync(this IServiceLocator locator, object target, CancellationToken cancellationToken)
 #else
-		public static Task InjectAsync(this IServiceKitLocator locator, object target, CancellationToken cancellationToken)
+		public static Task InjectAsync(this IServiceLocator locator, object target, CancellationToken cancellationToken)
 #endif
 		{
 			return locator.Inject(target)
@@ -31,7 +31,7 @@ namespace Nonatomic.ServiceKit
 		/// <summary>
 		/// Register a service with a factory function
 		/// </summary>
-		public static void RegisterServiceFactory<T>(this IServiceKitLocator serviceKitLocator, Func<T> factory) where T : class
+		public static void RegisterServiceFactory<T>(this IServiceLocator serviceKitLocator, Func<T> factory) where T : class
 		{
 			serviceKitLocator.RegisterService(factory());
 		}
@@ -40,9 +40,9 @@ namespace Nonatomic.ServiceKit
 		/// Register a service asynchronously
 		/// </summary>
 #if SERVICEKIT_UNITASK
-		public static async UniTask RegisterServiceAsync<T>(this IServiceKitLocator serviceKitLocator, Task<T> serviceTask) where T : class
+		public static async UniTask RegisterServiceAsync<T>(this IServiceLocator serviceKitLocator, Task<T> serviceTask) where T : class
 #else
-		public static async Task RegisterServiceAsync<T>(this IServiceKitLocator serviceKitLocator, Task<T> serviceTask) where T : class
+		public static async Task RegisterServiceAsync<T>(this IServiceLocator serviceKitLocator, Task<T> serviceTask) where T : class
 #endif
 		{
 			var service = await serviceTask;
@@ -52,7 +52,7 @@ namespace Nonatomic.ServiceKit
 		/// <summary>
 		/// Check if a service is registered
 		/// </summary>
-		public static bool HasService<T>(this IServiceKitLocator serviceKitLocator) where T : class
+		public static bool HasService<T>(this IServiceLocator serviceKitLocator) where T : class
 		{
 			return serviceKitLocator.GetService<T>() != null;
 		}
@@ -60,7 +60,7 @@ namespace Nonatomic.ServiceKit
 		/// <summary>
 		/// Try to get a service and perform an action if it exists
 		/// </summary>
-		public static void WithService<T>(this IServiceKitLocator serviceKitLocator, Action<T> action) where T : class
+		public static void WithService<T>(this IServiceLocator serviceKitLocator, Action<T> action) where T : class
 		{
 			if (serviceKitLocator.TryGetService<T>(out var service))
 			{
@@ -71,7 +71,7 @@ namespace Nonatomic.ServiceKit
 		/// <summary>
 		/// Try to get a service and return a result if it exists
 		/// </summary>
-		public static TResult WithService<T, TResult>(this IServiceKitLocator serviceKitLocator, Func<T, TResult> func, TResult defaultValue = default) where T : class
+		public static TResult WithService<T, TResult>(this IServiceLocator serviceKitLocator, Func<T, TResult> func, TResult defaultValue = default) where T : class
 		{
 			return serviceKitLocator.TryGetService<T>(out var service) ? func(service) : defaultValue;
 		}

--- a/Runtime/ServiceRegistrationBuilder.cs
+++ b/Runtime/ServiceRegistrationBuilder.cs
@@ -9,7 +9,7 @@ namespace Nonatomic.ServiceKit
 	/// </summary>
 	public class ServiceRegistrationBuilder : IServiceRegistrationBuilder
 	{
-		private readonly IServiceKitLocator _locator;
+		private readonly IServiceLocator _locator;
 		private readonly object _service;
 		private readonly string _registeredBy;
 		private readonly List<Type> _serviceTypes = new();
@@ -18,7 +18,7 @@ namespace Nonatomic.ServiceKit
 		private bool _executed;
 
 		internal ServiceRegistrationBuilder(
-			IServiceKitLocator locator,
+			IServiceLocator locator,
 			object service,
 			[CallerMemberName] string registeredBy = null)
 		{

--- a/Samples~/9 - Complete Game Example/Scripts/Services/PlayerService.cs
+++ b/Samples~/9 - Complete Game Example/Scripts/Services/PlayerService.cs
@@ -42,8 +42,9 @@ namespace ServiceKitSamples.CompleteGameExample
 
 		protected override void InitializeService()
 		{
-			// Tag this service as "saveable" so SaveService can discover it dynamically
-			Locator.AddTagsToService<IPlayerService>("saveable");
+			// Tag this service as "saveable" so SaveService can discover it dynamically.
+			// Tags live on the full IServiceKitLocator; Locator is the core IServiceLocator facet, so cast.
+			((IServiceKitLocator)Locator).AddTagsToService<IPlayerService>("saveable");
 
 			Debug.Log("[PlayerService] Initialized");
 			Reset();

--- a/Samples~/9 - Complete Game Example/Scripts/Services/SaveService.cs
+++ b/Samples~/9 - Complete Game Example/Scripts/Services/SaveService.cs
@@ -39,7 +39,8 @@ namespace ServiceKitSamples.CompleteGameExample
 			Debug.Log("[SaveService] Saving game...");
 
 			// Discover all saveable services dynamically via the "saveable" tag
-			var saveableServices = Locator.GetServicesWithTag("saveable");
+			// Tags live on the full IServiceKitLocator; Locator is the core IServiceLocator facet, so cast.
+			var saveableServices = ((IServiceKitLocator)Locator).GetServicesWithTag("saveable");
 			var saveData = new Dictionary<string, string>();
 
 			foreach (var serviceInfo in saveableServices)
@@ -84,7 +85,8 @@ namespace ServiceKitSamples.CompleteGameExample
 			}
 
 			// Discover all saveable services and restore their data
-			var saveableServices = Locator.GetServicesWithTag("saveable");
+			// Tags live on the full IServiceKitLocator; Locator is the core IServiceLocator facet, so cast.
+			var saveableServices = ((IServiceKitLocator)Locator).GetServicesWithTag("saveable");
 			var loadedCount = 0;
 
 			foreach (var serviceInfo in saveableServices)

--- a/Tests/EditMode/UseLocatorTests.cs
+++ b/Tests/EditMode/UseLocatorTests.cs
@@ -73,6 +73,20 @@ namespace Tests.EditMode
 		}
 
 		[Test]
+		public void UseLocator_AcceptsCoreIServiceLocator_NotJustFullInterface()
+		{
+			// The point of the facet split: a custom locator only needs to implement the core
+			// IServiceLocator, not the full IServiceKitLocator. This test compiles (and passes) only
+			// because UseLocator/ResolveLocator are typed to IServiceLocator - it would not build before.
+			var behaviour = CreateTestBehaviour();
+			IServiceLocator coreLocator = Substitute.For<IServiceLocator>();
+
+			behaviour.UseLocator(coreLocator);
+
+			Assert.Pass("UseLocator accepts a core IServiceLocator implementation");
+		}
+
+		[Test]
 		public void UseLocator_WithRealLocator_WorksAsExpected()
 		{
 			// Arrange

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.nonatomic.servicekit",
-  "version": "2.6.1",
+  "version": "3.0.0",
   "displayName": "Service Kit",
   "description": "A lightweight dependency injection and service locator framework for Unity. Attribute-based registration, async resolution, fluent API, optional dependencies, service tags, scene-aware lifecycle, and UniTask support.",
   "unity": "2022.3",


### PR DESCRIPTION
## 3.0.0 — narrow the injection surface to the core `IServiceLocator` facet

Completes the custom-locator story the 2.6.0 facet split set up. A custom locator now only has to implement the **core `IServiceLocator`** (register / ready / resolve / inject) instead of the full ~70-member `IServiceKitLocator` with its tag, scene, and diagnostics facets.

### Changed (breaking)
- `ServiceKitBehaviour.ResolveLocator()` returns `IServiceLocator`, `UseLocator()` accepts one, and the protected `Locator` property is `IServiceLocator`.
- `ServiceInjectionBuilder`, `ServiceRegistrationBuilder`, and the `ServiceKitExtensions` helpers (`InjectAsync`, `HasService`, `WithService`, `RegisterServiceFactory`, `RegisterServiceAsync`) were narrowed to `IServiceLocator`.
- All verified to use only core members. `IServiceKitLocator` still inherits all four facets; the concrete `ServiceKitLocator` is unchanged.

A new test (`UseLocator_AcceptsCoreIServiceLocator_NotJustFullInterface`) proves a bare `IServiceLocator` is now accepted — it would not have compiled before.

### Migration
- **Unaffected:** serialized `ServiceKitLocator` fields, `UseLocator(someServiceKitLocator)`, and `ResolveLocator()` overrides returning `IServiceKitLocator` (covariant return) all keep compiling.
- **The one break:** a `ServiceKitBehaviour` that uses a **tag / scene / diagnostics** member *through* `Locator` must cast — `((IServiceKitLocator)Locator).AddTagsToService(...)`. This is the genuine ergonomic cost of the narrowing; the Complete Game Example sample was updated to demonstrate it. Behaviours using only core members (register/ready/inject — the overwhelming majority) need no change.

### Validation
| Config | EditMode | PlayMode |
| --- | --- | --- |
| Default (no UniTask) | 115 / 115 | 19 / 19 |
| UniTask 2.5.10 | 113 / 113 | 19 / 19 |

### Not included
The god-class extraction (pulling tag/scene subsystems out of `ServiceKitLocator`) was **deliberately left out** — those subsystems read the core service dictionaries and aren't cleanly separable, so extracting them is high-risk work on tested code for marginal gain.
